### PR TITLE
Issue excluding some translations when no default and $var name

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -25,7 +25,11 @@
     generate/1,
     generate_file/2,
     file/1,
-    files/1]).
+    files/1,
+    is_variable_defined/2]).
+
+is_variable_defined(VariableDef, Conf) ->
+    lists:any(fun({X, _}) -> cuttlefish_util:fuzzy_variable_match(X, VariableDef) end, Conf). 
 
 files(ListOfConfFiles) ->
     lists:foldl(

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -78,14 +78,14 @@ map({Translations, Mappings, Validators} = Schema, Config) ->
         fun(MappingRecord, {ConfAcc, {MaybeDrop, Keep}}) ->
             Mapping = cuttlefish_mapping:mapping(MappingRecord),
             Default = cuttlefish_mapping:default(MappingRecord),
-            Key = cuttlefish_mapping:variable(MappingRecord),
+            Variable = cuttlefish_mapping:variable(MappingRecord),
             case {
-                Default =/= undefined orelse proplists:is_defined(Key, Conf), 
+                Default =/= undefined orelse cuttlefish_conf:is_variable_defined(Variable, Conf), 
                 proplists:is_defined(Mapping, Translations)
                 } of
                 {true, false} -> 
                     Tokens = string:tokens(Mapping, "."),
-                    NewValue = proplists:get_value(Key, Conf),
+                    NewValue = proplists:get_value(Variable, Conf),
                     {set_value(Tokens, ConfAcc, NewValue), {MaybeDrop, [Mapping|Keep]}};
                 {true, true} -> {ConfAcc, {MaybeDrop, [Mapping|Keep]}};
                 _ -> {ConfAcc, {[Mapping|MaybeDrop], Keep}}


### PR DESCRIPTION
Found this while writing the repl schema.

`Default =/= undefined orelse proplists:is_defined(Key, Conf)`

the above line didn't take into account if the Key was a fuzzy match.
