### PR TITLE
Enhancement to Datatypes

### DIFF
--- a/src/cuttlefish_bytesize.erl
+++ b/src/cuttlefish_bytesize.erl
@@ -40,22 +40,25 @@
 to_string(Bytez) ->
     case { Bytez rem ?GIGABYTE, Bytez rem ?MEGABYTE, Bytez rem ?KILOBYTE} of
         {0, _, _} ->
-            integer_to_list(Bytez div ?GIGABYTE) ++ "gb";
+            integer_to_list(Bytez div ?GIGABYTE) ++ "GB";
         {_, 0, _} ->
-            integer_to_list(Bytez div ?MEGABYTE) ++ "mb";
+            integer_to_list(Bytez div ?MEGABYTE) ++ "MB";
         {_, _, 0} ->
-            integer_to_list(Bytez div ?KILOBYTE) ++ "kb";
+            integer_to_list(Bytez div ?KILOBYTE) ++ "KB";
         _ ->
             integer_to_list(Bytez)
     end.
 
-%% @doc the reverse of to_string/1. turns "1kb" into 1024.
+%% @doc the reverse of to_string/1. turns "1kb" or "1KB" into 1024.
 -spec parse(string()) -> integer()|error.
 parse(String) ->
     try
         case lists:reverse(String) of
+            [$B,$K|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?KILOBYTE;
             [$b,$k|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?KILOBYTE;
+            [$B,$M|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?MEGABYTE;
             [$b,$m|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?MEGABYTE;
+            [$B,$G|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?GIGABYTE;
             [$b,$g|BSize] -> cuttlefish_util:numerify(lists:reverse(BSize)) * ?GIGABYTE;
             BSize -> cuttlefish_util:numerify(lists:reverse(BSize))
         end of
@@ -67,18 +70,18 @@ parse(String) ->
 
 -ifdef(TEST).
 to_string_test() ->
-    ?assertEqual("1kb", to_string(1024)),
-    ?assertEqual("2kb", to_string(2048)),
+    ?assertEqual("1KB", to_string(1024)),
+    ?assertEqual("2KB", to_string(2048)),
     ?assertEqual("20", to_string(20)),
-    ?assertEqual("10mb", to_string(10485760)),
+    ?assertEqual("10MB", to_string(10485760)),
     ok.
 
 parse_test() ->
     ?assertEqual(1024, parse("1kb")),
-    ?assertEqual(2048, parse("2kb")),
+    ?assertEqual(2048, parse("2KB")),
     ?assertEqual(20, parse("20")),
     ?assertEqual(10485760, parse("10mb")),
-    ?assertEqual(error, parse("10mb10kb")),
+    ?assertEqual(error, parse("10MB10kb")),
     ok.
 
 -endif.

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -53,15 +53,6 @@ file(Filename) ->
             remove_duplicates(Conf)
     end.
 
-%%validate(Schema, Config) ->
-%%    %% For each config item, find the mapping and try converting that datertype
-%%    [ begin
-%%        Mapping = cuttlefish_generator:find_mapping(Key, Schema),
-%%        cuttlefish_mapping:datatype(Mapping),
-%%        ok 
-%%    end || {Key, _Value} <- Config],
-%%    ok.
-
 generate(Schema) ->
     lists:foldl(
         fun(SchemaElement, ConfFile) ->

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -303,8 +303,8 @@ transform_datatypes(Conf, Mappings) ->
                         {_, {error, Message}} ->
                             lager:error("Bad datatype: ~s ~s", [string:join(Variable, "."), Message]),
                             Acc;
-                        {enum, NewValue} ->
-                            case lists:member(NewValue, cuttlefish_mapping:enum(MappingRecord)) of
+                        {{enum, PossibleValues}, NewValue} ->
+                            case lists:member(NewValue, PossibleValues) of
                                 true -> [{Variable, NewValue}|Acc];
                                 false ->  
                                     lager:error("Bad value: ~s for enum ~s", [NewValue, Variable]),

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -350,7 +350,7 @@ find_mapping(Variable, Mappings) ->
 bad_conf_test() ->
     Conf = [
         {["integer_thing"], "thirty_two"},
-        {["enum_thing"], "bad_enum_value"},
+        {["enum_thing"], bad_enum_value},
         {["ip_thing"], "not an IP address"}
     ],
 
@@ -359,8 +359,7 @@ bad_conf_test() ->
             {datatype, integer}
         ]}),
         cuttlefish_mapping:parse({mapping, "enum_thing", "to.enum", [
-            {datatype, enum},
-            {enum, [on, off]}
+            {datatype, {enum, [on, off]}}
         ]}),
         cuttlefish_mapping:parse({mapping, "ip_thing", "to.ip", [
             {datatype, ip}
@@ -545,7 +544,7 @@ validation_test() ->
     Pid = self(),
 
     Mappings = [cuttlefish_mapping:parse(
-        {mapping, "a", "b.c", [{validators, ["a"]}, {datatype, enum}, {enum, [true, false]}]}
+        {mapping, "a", "b.c", [{validators, ["a"]}, {datatype, {enum, [true, false]}}]}
         )
     ],
 

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -73,7 +73,7 @@ files(ListOfSchemaFiles) ->
 -spec file(string()) -> {
     [cuttlefish_translation:translation()], 
     [cuttlefish_mapping:mapping()],
-    [cuttlefish_mapping:validator()]
+    [cuttlefish_validator:validator()]
 } | error.
 file(Filename) ->
     {ok, B} = file:read_file(Filename),
@@ -90,7 +90,7 @@ file(Filename) ->
 -spec string(string()) -> {
     [cuttlefish_translation:translation()], 
     [cuttlefish_mapping:mapping()],
-    [cuttlefish_mapping:validator()]
+    [cuttlefish_validator:validator()]
 } | {error, [errorlist()]}.
 string(S) -> 
     case erl_scan:string(S) of

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -7,8 +7,7 @@
 %% mechanism that will be used on this node.
 {mapping, "multi_backend.$name.storage_backend", "riak_kv.multi_backend", [
   {default, bitcask},
-  {datatype, enum},
-  {enum, [bitcask, leveldb, memory]}
+  {datatype, {enum, [bitcask, leveldb, memory]}}
 ]}.
 
 {translation,
@@ -94,13 +93,12 @@
 %%  * `interval` - Riak will force Bitcask to sync every `bitcask.sync_interval` seconds.
 {mapping, "multi_backend.$name.bitcask.sync_strategy", "riak_kv.multi_backend", [
   {default, none},
-  {datatype, enum},
-  {enum, [none, o_sync, interval]},
+  {datatype, {enum, [none, o_sync, interval]}},
   {level, advanced}
 ]}.
 
 {mapping, "multi_backend.$name.bitcask.sync_interval", "riak_kv.multi_backend", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {level, advanced}
 ]}.
 
@@ -129,8 +127,7 @@
 %% want to change this setting from the default.
 {mapping, "multi_backend.$name.bitcask.merge_window", "riak_kv.multi_backend", [
   {default, always},
-  {datatype, enum},
-  {enum, [always, never, window]},
+  {datatype, {enum, [always, never, window]}},
   {level, advanced}
 ]}.
 
@@ -242,7 +239,7 @@
 %% 
 %% Default is: `-1` which disables automatic expiration
 {mapping, "multi_backend.$name.bitcask.expiry", "riak_kv.multi_backend", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {level, advanced},
   {default, -1}
 ]}.
@@ -255,8 +252,7 @@
 %% become the default setting in a future release.
 {mapping, "multi_backend.$name.bitcask.require_hint_crc", "riak_kv.multi_backend", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -269,7 +265,7 @@
 %%
 %% Default is: `0`
 {mapping, "multi_backend.$name.bitcask.expiry_grace_time", "riak_kv.multi_backend", [
-  {datatype, duration_secs},
+  {datatype, {duration, secs}},
   {level, advanced},
   {default, 0}
 ]}.
@@ -284,8 +280,7 @@
 %% and possible throughput collapse.
 {mapping, "multi_backend.$name.bitcask.io_mode", "riak_kv.multi_backend", [
   {default, erlang},
-  {datatype, enum},
-  {enum, [erlang, nif]}
+  {datatype, {enum, [erlang, nif]}}
 ]}.
 
 %%%% This is the leveldb section
@@ -325,8 +320,7 @@
 %% the physical disks. This flag influences only one of the layers.
 {mapping, "multi_backend.$name.leveldb.sync", "riak_kv.multi_backend", [
   {default, false},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -354,8 +348,7 @@
 %% in the riak.conf to take effect.
 {mapping, "multi_backend.$name.leveldb.bloomfilter", "riak_kv.multi_backend", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 %% @doc sst_block_size defines the size threshold for a block / chunk of data 
@@ -380,8 +373,7 @@
 %% requests data from the leveldb database on behalf of the user.
 {mapping, "multi_backend.$name.leveldb.verify_checksums", "riak_kv.multi_backend", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -389,8 +381,7 @@
 %% leveldb reads data as part of its background compaction operations.
 {mapping, "multi_backend.$name.leveldb.verify_compaction", "riak_kv.multi_backend", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -403,7 +394,7 @@
 ]}.
 
 {mapping, "multi_backend.$name.memory_backend.ttl", "riak_kv.multi_backend", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {commented, "1d"}, %% no default, it's undefined.
   {level, advanced}
 ]}.

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -107,7 +107,7 @@
 %% file to exceed this size threshold then that file is closed, and a new file
 %% is opened for writes.
 {mapping, "multi_backend.$name.bitcask.max_file_size", "riak_kv.multi_backend", [
-  {default, "2gb"},
+  {default, "2GB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -172,7 +172,7 @@
 {mapping, "multi_backend.$name.bitcask.dead_bytes_merge_trigger", "riak_kv.multi_backend", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "512mb"}
+  {default, "512MB"}
 ]}.
 
 %% @doc `frag_threshold` setting describes what ratio of
@@ -199,7 +199,7 @@
 {mapping, "multi_backend.$name.bitcask.dead_bytes_threshold", "riak_kv.multi_backend", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "128mb"}
+  {default, "128MB"}
 ]}.
 
 %% @doc `small_file_threshold` setting describes the minimum
@@ -212,7 +212,7 @@
 {mapping, "multi_backend.$name.bitcask.small_file_threshold", "riak_kv.multi_backend", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "10mb"}
+  {default, "10MB"}
 ]}.
 
 %% @doc Fold keys thresholds will reuse the keydir if another fold was started less
@@ -307,7 +307,7 @@
 %% access to adjacent keys.
 {mapping, "multi_backend.$name.leveldb.cache_size", "riak_kv.multi_backend", [
   {datatype, bytesize},
-  {default, "8mb"},
+  {default, "8MB"},
   {level, advanced}
 ]}.
 
@@ -330,13 +330,13 @@
 %% write buffer for performance reasons. The random size is somewhere 
 %% between write_buffer_size_min and write_buffer_size_max.
 {mapping, "multi_backend.$name.leveldb.write_buffer_size_min", "riak_kv.multi_backend", [
-  {default, "15mb"},
+  {default, "15MB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
 
 {mapping, "multi_backend.$name.leveldb.write_buffer_size_max", "riak_kv.multi_backend", [
-  {default, "30mb"},
+  {default, "30MB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -355,7 +355,7 @@
 %% within one .sst table file. Each new block gets an index entry in the .sst
 %% table file's master index.
 {mapping, "multi_backend.$name.leveldb.block_size", "riak_kv.multi_backend", [
-  {default, "4kb"},
+  {default, "4KB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -389,7 +389,7 @@
 
 {mapping, "multi_backend.$name.memory_backend.max_memory", "riak_kv.multi_backend", [
   {datatype, bytesize},
-  {default, "4gb"},
+  {default, "4GB"},
   {level, advanced}
 ]}.
 

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -16,8 +16,7 @@
 %% Slightly more complex mapping with translation layer
 %% @doc enable active anti-entropy subsystem
 {mapping, "anti_entropy", "riak_kv.anti_entropy", [
-  {datatype, enum},
-  {enum, [on, off, debug]},
+  {datatype, {enum, [on, off, debug]}},
   {default, on}
 ]}.
 
@@ -50,8 +49,7 @@
 %% @doc turn on syslog
 {mapping, "log.syslog", "lager.handlers", [
   {default, off},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -77,8 +75,7 @@
 %% We should never care about this
 {mapping, "sasl", "sasl.sasl_error_logger", [
   {default, off},
-  {datatype, enum},
-  {enum, [on, off]},
+  {datatype, {enum, [on, off]}},
   {level, advanced}
 ]}.
 
@@ -195,8 +192,7 @@
 %% source repository & branch.
 {mapping, "dtrace", "riak_core.dtrace_support", [
   {default, off},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 %% consistent on/off (in lieu of enabled/disabled, true/false)
@@ -237,8 +233,7 @@
 %% @datatype enum on, off
 {mapping, "search", "riak_search.enabled", [
   {default, off},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -314,8 +309,7 @@ end}.
 %% @doc Whether to redirect error_logger messages into lager - defaults to true
 {mapping, "log.error.redirect", "lager.error_logger_redirect", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -340,8 +334,7 @@ end}.
 %% mechanism that will be used on this node.
 {mapping, "storage_backend", "riak_kv.storage_backend", [
   {default, bitcask},
-  {datatype, enum},
-  {enum, [bitcask, leveldb, memory, multi]}
+  {datatype, {enum, [bitcask, leveldb, memory, multi]}}
 ]}.
 
 { translation,
@@ -377,7 +370,7 @@ end}.
 
 {mapping, "anti_entropy.build_limit.per_timespan", "riak_kv.anti_entropy_build_limit", [
   {default, "1h"},
-  {datatype, duration}
+  {datatype, {duration, ms}}
 ]}.
 
 {translation,
@@ -396,7 +389,7 @@ end}.
 %% milliseconds. The default is 1 week.
 {mapping, "anti_entropy.expire", "riak_kv.anti_entropy_expire", [
   {default, "1w"},
-  {datatype, duration}
+  {datatype, {duration, ms}}
 ]}.
 
 %% @doc Limit how many AAE exchanges/builds can happen concurrently.
@@ -412,7 +405,7 @@ end}.
 %% Increasing the value is not recommended.
 {mapping, "anti_entropy.tick", "riak_kv.anti_entropy_tick", [
   {default, "15s"},
-  {datatype, duration}
+  {datatype, {duration, ms}}
 ]}.
 
 %% @doc The directory where AAE hash trees are stored.
@@ -444,8 +437,7 @@ end}.
 %% undefined during a rolling upgrade from 1.0.
 {mapping, "mapred_2i_pipe", "riak_kv.mapred_2i_pipe", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -507,8 +499,7 @@ end}.
 %% mode will be removed in a future release.
 {mapping, "http_url_encoding", "riak_kv.http_url_encoding", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 %% @doc Switch to vnode-based vclocks rather than client ids.  This
@@ -516,8 +507,7 @@ end}.
 %% Only set on if *all* nodes in the cluster are upgraded to 1.0
 {mapping, "vnode_vclocks", "riak_kv.vnode_vclocks", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}  
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -538,8 +528,7 @@ end}.
 %% operations
 {mapping, "listkeys_backpressure", "riak_kv.listkeys_backpressure", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]} 
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -570,8 +559,7 @@ end}.
 %% v1: New format for more compact storage of small values.
 {mapping, "object_format", "riak_kv.object_format", [
   {default, v1},
-  {datatype, enum},
-  {enum, [v0, v1]}
+  {datatype, {enum, [v0, v1]}}
 ]}.
 
 %% riak_sysmon config
@@ -608,14 +596,12 @@ end}.
 %% of that event type.
 {mapping, "riak_sysmon.busy_port", "riak_sysmon.busy_port", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 {mapping, "riak_sysmon.busy_dist_port", "riak_sysmon.busy_dist_port", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -623,9 +609,9 @@ end}.
 %% @doc Set to false to disable the admin panel.
 {mapping, "riak_control", "riak_control.enabled", [
   {default, off},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
+
 {translation,
  "riak_control.enabled",
  fun(Conf) ->
@@ -641,8 +627,7 @@ end}.
 %% panel. Valid styles are 'userlist' <TODO>.
 {mapping, "riak_control.auth", "riak_control.auth", [
   {default, userlist},
-  {datatype, enum},
-  {enum, [userlist]}
+  {datatype, {enum, [userlist]}}
 ]}.
 
 %% @doc If auth is set to 'userlist' then this is the
@@ -673,8 +658,7 @@ end}.
 %% by one of these settings.
 {mapping, "riak_control.admin", "riak_control.admin", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 {translation,
@@ -732,13 +716,12 @@ end}.
 %%  * `interval` - Riak will force Bitcask to sync every `bitcask.sync_interval` seconds.
 {mapping, "bitcask.sync_strategy", "bitcask.sync_strategy", [
   {default, none},
-  {datatype, enum},
-  {enum, [none, o_sync, interval]},
+  {datatype, {enum, [none, o_sync, interval]}},
   {level, advanced}
 ]}.
 
 {mapping, "bitcask.sync_interval", "bitcask.sync_strategy", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {level, advanced}
 ]}.
 
@@ -781,8 +764,7 @@ end}.
 %% want to change this setting from the default.
 {mapping, "bitcask.merge_window", "bitcask.merge_window", [
   {default, always},
-  {datatype, enum},
-  {enum, [always, never, window]},
+  {datatype, {enum, [always, never, window]}},
   {level, advanced}
 ]}.
 
@@ -910,7 +892,7 @@ end}.
 %% 
 %% Default is: `-1` which disables automatic expiration
 {mapping, "bitcask.expiry", "bitcask.expiry_secs", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {level, advanced},
   {default, -1}
 ]}.
@@ -923,8 +905,7 @@ end}.
 %% become the default setting in a future release.
 {mapping, "bitcask.require_hint_crc", "bitcask.require_hint_crc", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -937,7 +918,7 @@ end}.
 %%
 %% Default is: `0`
 {mapping, "bitcask.expiry_grace_time", "bitcask.expiry_grace_time", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {level, advanced},
   {default, 0}
 ]}.
@@ -952,8 +933,7 @@ end}.
 %% and possible throughput collapse.
 {mapping, "bitcask.io_mode", "bitcask.io_mode", [
   {default, erlang},
-  {datatype, enum},
-  {enum, [erlang, nif]}
+  {datatype, {enum, [erlang, nif]}}
 ]}.
 
 %%%% This is the leveldb section
@@ -993,8 +973,7 @@ end}.
 %% the physical disks. This flag influences only one of the layers.
 {mapping, "leveldb.sync", "eleveldb.sync", [
   {default, false},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -1022,8 +1001,7 @@ end}.
 %% in the riak.conf to take effect.
 {mapping, "leveldb.bloomfilter", "eleveldb.use_bloomfilter", [
   {default, on},
-  {datatype, enum},
-  {enum, [on, off]}
+  {datatype, {enum, [on, off]}}
 ]}.
 
 { translation,
@@ -1059,8 +1037,7 @@ end}.
 %% requests data from the leveldb database on behalf of the user.
 {mapping, "leveldb.verify_checksums", "eleveldb.verify_checksums", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -1068,8 +1045,7 @@ end}.
 %% leveldb reads data as part of its background compaction operations.
 {mapping, "leveldb.verify_compaction", "eleveldb.verify_compaction", [
   {default, true},
-  {datatype, enum},
-  {enum, [true, false]},
+  {datatype, {enum, [true, false]}},
   {level, advanced}
 ]}.
 
@@ -1090,7 +1066,7 @@ end}.
 }.
 
 {mapping, "memory_backend.ttl", "riak_kv.memory_backend.ttl", [
-  {datatype, duration_secs},
+  {datatype, {duration, s}},
   {commented, "1d"}, %% no default, it's undefined.
   {level, advanced}
 ]}.

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -256,7 +256,7 @@ end}.
 %% threshold has been reached the data is transformed
 %% into a segment file which resides on disk.
 {mapping, "merge_index.buffer_rollover_size", "merge_index.buffer_rollover_size", [
-  {default, "1mb"},
+  {default, "1MB"},
   {datatype, bytesize}
 ]}.
 
@@ -281,14 +281,14 @@ end}.
 %% @datatype integer
 %% @mapping 
 {mapping, "log.crash.msg_size", "lager.crash_log_msg_size", [
-  {default, "64kb"},
+  {default, "64KB"},
   {datatype, bytesize}
 ]}.
 
 %% @doc Maximum size of the crash log in bytes, before its rotated, set
 %% to 0 to disable rotation - default is 0
 {mapping, "log.crash.size", "lager.crash_log_size", [
-  {default, "10mb"},
+  {default, "10MB"},
   {datatype, bytesize}
 ]}.
 
@@ -416,7 +416,7 @@ end}.
 %% @doc The LevelDB options used by AAE to generate the LevelDB-backed
 %% on-disk hashtrees.
 {mapping, "anti_entropy.write_buffer_size", "riak_kv.anti_entropy_leveldb_opts.write_buffer_size", [
-  {default, "4mb"},
+  {default, "4MB"},
   {datatype, bytesize}
 ]}.
 
@@ -744,7 +744,7 @@ end}.
 %% file to exceed this size threshold then that file is closed, and a new file
 %% is opened for writes.
 {mapping, "bitcask.max_file_size", "bitcask.max_file_size", [
-  {default, "2gb"},
+  {default, "2GB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -825,7 +825,7 @@ end}.
 {mapping, "bitcask.dead_bytes_merge_trigger", "bitcask.dead_bytes_merge_trigger", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "512mb"}
+  {default, "512MB"}
 ]}.
 
 %% @doc `frag_threshold` setting describes what ratio of
@@ -852,7 +852,7 @@ end}.
 {mapping, "bitcask.dead_bytes_threshold", "bitcask.dead_bytes_threshold", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "128mb"}
+  {default, "128MB"}
 ]}.
 
 %% @doc `small_file_threshold` setting describes the minimum
@@ -865,7 +865,7 @@ end}.
 {mapping, "bitcask.small_file_threshold", "bitcask.small_file_threshold", [
   {datatype, bytesize},
   {level, advanced},
-  {default, "10mb"}
+  {default, "10MB"}
 ]}.
 
 %% @doc Fold keys thresholds will reuse the keydir if another fold was started less
@@ -960,7 +960,7 @@ end}.
 %% access to adjacent keys.
 {mapping, "leveldb.cache_size", "eleveldb.cache_size", [
   {datatype, bytesize},
-  {default, "8mb"},
+  {default, "8MB"},
   {level, advanced}
 ]}.
 
@@ -983,13 +983,13 @@ end}.
 %% write buffer for performance reasons. The random size is somewhere 
 %% between write_buffer_size_min and write_buffer_size_max.
 {mapping, "leveldb.write_buffer_size_min", "eleveldb.write_buffer_size_min", [
-  {default, "30mb"},
+  {default, "30MB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
 
 {mapping, "leveldb.write_buffer_size_max", "eleveldb.write_buffer_size_max", [
-  {default, "60mb"},
+  {default, "60MB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -1019,7 +1019,7 @@ end}.
 %% within one .sst table file. Each new block gets an index entry in the .sst
 %% table file's master index.
 {mapping, "leveldb.block_size", "eleveldb.sst_block_size", [
-  {default, "4kb"},
+  {default, "4KB"},
   {datatype, bytesize},
   {level, advanced}
 ]}.
@@ -1053,7 +1053,7 @@ end}.
 
 {mapping, "memory_backend.max_memory", "riak_kv.memory_backend.max_memory", [
   {datatype, bytesize},
-  {default, "4gb"},
+  {default, "4GB"},
   {level, advanced}
 ]}.
 
@@ -1145,7 +1145,7 @@ end}.
 %% The Erlang/OTP default is 1024 (1 megabyte).
 %% See: http://www.erlang.org/doc/man/erl.html#%2bzdbbl
 {mapping, "erlang.zdouble", "vm_args.+zdbbl", [
-  {commented, "32mb"},
+  {commented, "32MB"},
   {datatype, bytesize}
 ]}.
 


### PR DESCRIPTION
Addreses: #24 and what remains of #6 

The following changes have been made to the `datatype` element of a mapping:
- **enum** has been replaced with {enum, [atom()]} where the list of atoms are possible values for the enum
- **duration** and **duration_secs** have been replaced with {duration, Unit} where unit is the unit you'd like to end up with and it's one of: f, w, d, h, m, s, ms

Also, the **enum** element of a mapping no longer does anything.

Bytesizes now default to capital letters: GB, MB, KB. lowercase, still works, but mixed case does not (because it's ugly and to avoid confusion with Mega**bit**s) 
