### PR TITLE
Make cuttlefish return the right -config line to node_package

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -76,10 +76,11 @@ main(Args) ->
     case filelib:is_file(filename:join(EtcDir, "app.config")) of
         true ->
             AppConf = filename:join(EtcDir, "app.config"),
+            AppArgs = filename:join(EtcDir, "vm.args"),
             lager:info("~s exists, disabling cuttlefish.", [AppConf]),
             lager:info("If you'd like to know more about cuttlefish, check your local library!", []),
             lager:info(" or see http://github.com/basho/cuttlefish", []),
-            ?STDOUT("~s", [AppConf]),
+            ?STDOUT("-config ~s -args_file ~s", [AppConf, AppArgs]),
             halt(0);
         _ ->
             %% Just keep going


### PR DESCRIPTION
Currently, node_package either generates CONFIG_ARGS line itself or
expects cuttlefish to generate one. In the case of cuttlefish
encountering an existing app.config it simply returned the path to the
app.config file, which is not what node_package expects. This patch
adjusts cuttlefish to return the -config and -args_file string that
would be returned were cuttlefish to be disabled.
