### PR TITLE
Always use absolute paths for generated files

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -124,14 +124,18 @@ main(Args) ->
                     init:stop(1)
             end 
     end,
+    AbsPath = case DestinationPath of
+                          [$/|_] -> DestinationPath;
+                          _      -> filename:join(element(2,file:get_cwd()), DestinationPath)
+                      end,
 
     Date = calendar:local_time(),
 
     DestinationFilename = filename_maker(proplists:get_value(dest_file, ParsedArgs), Date, "config"),
-    Destination = filename:join(DestinationPath, DestinationFilename),
+    Destination = filename:join(AbsPath, DestinationFilename),
 
     DestinationVMArgsFilename = filename_maker("vm", Date, "args"),
-    DestinationVMArgs = filename:join(DestinationPath, DestinationVMArgsFilename),
+    DestinationVMArgs = filename:join(AbsPath, DestinationVMArgsFilename),
 
     lager:debug("Generating config in: ~p", [Destination]),
     lager:debug("ConfFiles: ~p", [ConfFiles]),


### PR DESCRIPTION
Generated files moved out of the `etc` directory recently and into the `data` directory.  The infrastructure in riak_test was confused by the move, due to differences using relative paths and different $CWD between chkconfig and riak_test.  Use absolute paths.
