### PR TITLE
Logging improvements to cuttlefish

### DIFF
--- a/src/cuttlefish_advanced.erl
+++ b/src/cuttlefish_advanced.erl
@@ -34,7 +34,7 @@
 overlay(GeneratedConfig, AdvancedConfig) ->
     lists:foldl(
         fun({ApplicationName, ApplicationConfig}, OuterAcc) ->
-            GeneratedApplicationConfig = proplists:get_value(ApplicationName, GeneratedConfig),
+            GeneratedApplicationConfig = proplists:get_value(ApplicationName, GeneratedConfig, []),
             Updated = lists:foldl(
                 fun({ConfigElementName, ConfigElement}, Acc) -> 
                     cuttlefish_util:replace_proplist_value(ConfigElementName, ConfigElement, Acc) 
@@ -57,13 +57,15 @@ overlay_test() ->
     ],
 
     AdvancedConfig = [
-        {app3, [{'setting3.1', i_dont_care}]}
+        {app3, [{'setting3.1', i_dont_care}]},
+        {app4, [{'some_unschemad_thing', 'like_a_penguin'}]}
     ],
 
     Expected = [
         {app1, [{'setting1.1', "value1.1"}]},
         {app2, [{'setting2.1', "value2.1"}]},
-        {app3, [{'setting3.1', i_dont_care}]}
+        {app3, [{'setting3.1', i_dont_care}]},
+        {app4, [{'some_unschemad_thing', 'like_a_penguin'}]}
     ],
     NewConfig = overlay(GeneratedConfig, AdvancedConfig),
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -110,8 +110,15 @@ map({Translations, Mappings, Validators} = Schema, Config) ->
                     Arity = proplists:get_value(arity, erlang:fun_info(Xlat)),
                     NewValue = case Arity of 
                         1 ->
-                            Xlat(Conf);
+                            lager:debug("Running translation for ~s", [Mapping]),
+                            try Xlat(Conf) of
+                                X -> X
+                            catch
+                                E:R ->
+                                    lager:error("Error running translation for ~s, [~p, ~p].", [Mapping, E, R])
+                            end;
                         2 -> 
+                            lager:debug("Running translation for ~s", [Mapping]),
                             Xlat(Conf, Schema);
                         Other -> 
                             lager:error("~p is not a valid arity for translation fun() ~s. Try 1 or 2.", [Other, Mapping]),

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -119,7 +119,12 @@ map({Translations, Mappings, Validators} = Schema, Config) ->
                             end;
                         2 -> 
                             lager:debug("Running translation for ~s", [Mapping]),
-                            Xlat(Conf, Schema);
+                            try Xlat(Conf, Schema) of
+                                X -> X
+                            catch
+                                E:R ->
+                                    lager:error("Error running translation for ~s, [~p, ~p].", [Mapping, E, R])
+                            end;
                         Other -> 
                             lager:error("~p is not a valid arity for translation fun() ~s. Try 1 or 2.", [Other, Mapping]),
                             undefined


### PR DESCRIPTION
Added the ability to pass a log level to the escript

added a log message for errors caught when running translations

also fixed a bug @vinoski found when trying to add an erlang application to the advanced.config, which is completely unknown to the generated config.
