### PR TITLE
not be too crazy strict about the lager version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
-    {lager, "2.0.0", {git, "git://github.com/basho/lager.git", {tag, "2.0.0"}}},
+    {lager, "2.0.*", {git, "git://github.com/basho/lager.git", {tag, "2.0.0"}}},
     {neotoma, "1.6.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.6.2"}}},
     {kvc, ".*", {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}}
   ]}.


### PR DESCRIPTION
Relaxing the dependency on the lager version a bit, this makes it more sane to work together with other project and libraries that might use 2.0.1 or 2.0....

pretty please!
