### PR TITLE
Added lager output for badly formated advanced.config

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -284,8 +284,14 @@ engage_cuttlefish(ParsedArgs) ->
     FinalConfig = case filelib:is_file(AdvancedConfigFile) of
         true ->
             lager:info("~s/advanced.config detected, overlaying proplists", [EtcDir]),
-            {ok, [AdvancedConfig]} = file:consult(AdvancedConfigFile), 
-            cuttlefish_advanced:overlay(NewConfig, AdvancedConfig);
+            case file:consult(AdvancedConfigFile) of
+                {ok, [AdvancedConfig]} ->
+                    cuttlefish_advanced:overlay(NewConfig, AdvancedConfig);
+                {error, Error} ->
+                    lager:error("Error parsing advanced.config: ~p", [Error]),
+                    stop_deactivate()
+            end;
+            
         _ ->
             %% Nothing to see here, these aren't the droids you're looking for.
             NewConfig


### PR DESCRIPTION
As reported by @reiddraper in #49 

``` erlang
[{riak_kv,
    [
        {some_option, 2}
        {some_other, 3}
    ]
}].
```

see the missing ',' on line 3?

Here's the output now:

```
➜  riak_ee git:(develop) ✗ ./rel/riak/bin/riak chkconfig
09:07:13.459 [info] Application lager started on node nonode@nohost
09:07:13.459 [info] Checking /Users/joe/dev/basho/riak_ee/rel/riak/bin/../etc/app.config exists... false
09:07:13.459 [info] Checking /Users/joe/dev/basho/riak_ee/rel/riak/bin/../etc/vm.args exists... false
09:07:13.459 [info] No app.config or vm.args detected in /Users/joe/dev/basho/riak_ee/rel/riak/bin/../etc, activating cuttlefish
09:07:13.676 [info] Adding Defaults
09:07:13.679 [info] Applying Datatypes
09:07:13.693 [info] Validation
09:07:13.697 [info] Applied 1:1 Mappings
09:07:13.699 [info] Applied Translations
09:07:13.699 [info] /Users/joe/dev/basho/riak_ee/rel/riak/bin/../etc/advanced.config detected, overlaying proplists
09:07:13.700 [error] Error parsing advanced.config: {4,erl_parse,["syntax error before: ","'{'"]}
Error generating config with cuttlefish
```
