### PR TITLE
Suggested variables when undefined, and more

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -32,16 +32,16 @@
 cli_options() ->
 %% Option Name, Short Code, Long Code, Argument Spec, Help Message
 [
- {help,               $h, "help",        undefined,        "Print this usage page"},
- {etc_dir,            $e, "etc_dir",     {string, "/etc"}, "etc dir"},
- {dest_dir,           $d, "dest_dir",    string,           "specifies the directory to write the config file to"},
- {dest_file,          $f, "dest_file",   {string, "app"},  "the file name to write"},
- {schema_dir,         $s, "schema_dir",  string,           "a directory containing .schema files"},
- {schema_file,        $i, "schema_file", string,           "individual schema file, will be processed in command line order, after -s"},
- {conf_file,          $c, "conf_file",   string,           "a cuttlefish conf file, multiple files allowed"},
- {app_config,         $a, "app_config",  string,           "the advanced erlangy app.config"},
- {log_level,          $l, "log_level",   {string, "info"}, "log level for cuttlefish output"},
- {print_schema,       $p, "print",       undefined,        "prints schema mappings on stderr"}
+ {help,               $h, "help",        undefined,          "Print this usage page"},
+ {etc_dir,            $e, "etc_dir",     {string, "/etc"},   "etc dir"},
+ {dest_dir,           $d, "dest_dir",    string,             "specifies the directory to write the config file to"},
+ {dest_file,          $f, "dest_file",   {string, "app"},    "the file name to write"},
+ {schema_dir,         $s, "schema_dir",  string,             "a directory containing .schema files"},
+ {schema_file,        $i, "schema_file", string,             "individual schema file, will be processed in command line order, after -s"},
+ {conf_file,          $c, "conf_file",   string,             "a cuttlefish conf file, multiple files allowed"},
+ {app_config,         $a, "app_config",  string,             "the advanced erlangy app.config"},
+ {log_level,          $l, "log_level",   {string, "notice"}, "log level for cuttlefish output"},
+ {print_schema,       $p, "print",       undefined,          "prints schema mappings on stderr"}
 ].
 
 %% LOL! I wanted this to be halt 0, but honestly, if this escript does anything
@@ -73,7 +73,7 @@ main(Args) ->
     SuggestedLogLevel = list_to_atom(proplists:get_value(log_level, ParsedArgs)),
     LogLevel = case lists:member(SuggestedLogLevel, [debug, info, notice, warning, error, critical, alert, emergency]) of
         true -> SuggestedLogLevel;
-        _ -> info
+        _ -> notice
     end,
 
     application:set_env(lager, handlers, [{lager_stderr_backend, LogLevel}]),
@@ -90,8 +90,7 @@ main(Args) ->
             effective(ParsedArgs);
         describe ->
             describe(ParsedArgs, Extra);
-        Other ->
-            lager:info("Oops! All berries! ~s", [Other]),
+        _Other ->
             print_help()
     end.
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -321,7 +321,7 @@ transform_datatypes(Conf, Mappings) ->
                     %% that you're trying to set something that has no effect
                     VarName = string:join(Variable, "."),
                     lager:warning("You've tried to set ~s, but there is no setting with that name.", [VarName]),
-                    lager:warning("  it could be a typo. Did you mean one of these?"),
+                    lager:warning("  Did you mean one of these?"),
 
                     Possibilities = [ begin
                         MapVarName = string:join(cuttlefish_mapping:variable(M), "."),

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -320,7 +320,7 @@ transform_datatypes(Conf, Mappings) ->
                     %% It won't prevent anything from starting, but will let you know
                     %% that you're trying to set something that has no effect
                     VarName = string:join(Variable, "."),
-                    lager:warning("You've tried to set ~s, but there is no mapping", [VarName]),
+                    lager:warning("You've tried to set ~s, but there is no setting with that name.", [VarName]),
                     lager:warning("  it could be a typo. Did you mean one of these?"),
 
                     Possibilities = [ begin
@@ -328,14 +328,7 @@ transform_datatypes(Conf, Mappings) ->
                         {cuttlefish_util:levenshtein(VarName, MapVarName), MapVarName}
                     end || M <- Mappings],
                     Sorted = lists:sort(Possibilities),
-                    NumSuggest = 3,
-                    Top = case length(Sorted) > NumSuggest of
-                        true ->
-                            {S, _} = lists:split(NumSuggest, Sorted),
-                            S;
-                        false -> Sorted
-                    end, 
-                    [ lager:warning("    ~s", [T]) || {_, T} <- Top],
+                    [ lager:warning("    ~s", [T]) || {_, T} <- lists:sublist(Sorted, 3) ],
                     Acc;
                 MappingRecord ->
                     DT = cuttlefish_mapping:datatype(MappingRecord),

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -327,21 +327,22 @@ files_test() ->
     {Translations, Mappings, Validations} = files(["../test/multi1.schema", "../test/multi2.schema"]),
     ?assertEqual(2, length(Mappings)),
     [M1, M2] = Mappings,
-    ?assertEqual(["a","b","d"], cuttlefish_mapping:variable(M1)),
-    ?assertEqual("what.ev1", cuttlefish_mapping:mapping(M1)),
+    ?assertEqual(["a","b","c"], cuttlefish_mapping:variable(M1)),
+    ?assertEqual("what.ev4", cuttlefish_mapping:mapping(M1)),
 
-    ?assertEqual(["a","b","c"], cuttlefish_mapping:variable(M2)),
-    ?assertEqual("what.ev4", cuttlefish_mapping:mapping(M2)),
+    ?assertEqual(["a","b","d"], cuttlefish_mapping:variable(M2)),
+    ?assertEqual("what.ev1", cuttlefish_mapping:mapping(M2)),
 
     ?assertEqual(2, length(Translations)),
     [T1, T2] = Translations,
-    ?assertEqual("what.ev2", cuttlefish_translation:mapping(T1)),
-    F1 = cuttlefish_translation:func(T1),
-    ?assertEqual(1, F1(x)),
 
-    ?assertEqual("what.ev1", cuttlefish_translation:mapping(T2)),
+    ?assertEqual("what.ev1", cuttlefish_translation:mapping(T1)),
+    F1 = cuttlefish_translation:func(T1),
+    ?assertEqual(4, F1(x)),
+
+    ?assertEqual("what.ev2", cuttlefish_translation:mapping(T2)),
     F2 = cuttlefish_translation:func(T2),
-    ?assertEqual(4, F2(x)),
+    ?assertEqual(1, F2(x)),
 
     ?assertEqual(1, length(Validations)),
     [V1] = Validations,


### PR DESCRIPTION
A couple of little fixes, but let's start with the headlining feature.
### sugestions when variable doesn't exist

I tried setting `anti_entrophy = on` in my riak.conf, this was the output

```
➜  riak_ee git:(develop) ✗ ./rel/riak/bin/riak config generate
10:57:23.202 [warning] You've tried to set anti_entrophy, but there is no mapping
10:57:23.202 [warning]   it could be a typo. Did you mean one of these?
10:57:23.218 [warning]     anti_entropy
10:57:23.218 [warning]     anti_entropy.tick
10:57:23.218 [warning]     anti_entropy.expire
```

Oh yeah, suggestions when you make a mistake! This addresses #15 but in a larger than life kind of way

This PR also fixes #19 and #47, which were pretty much the same issue anyway.

Also, @reiddraper noticed a broken test, which I broke in previous merge, but the functionality was correct, I just had to alter the test to compensate.
