### PR TITLE
Fixes github issue #16. config file name no longer hardcoded

### DIFF
--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -51,9 +51,14 @@ generate(Config0, ReltoolFile) ->
                     io:format("Schema: ~p~n", [Schemas]),
 
                     {_Translations, Mappings, _Validators} = cuttlefish_schema:files(Schemas),
-                    
-                    %% TODO: output file configurable
-                    Filename = filename:join([TargetDir, "etc", "riak.conf"]),
+
+                    %% I really wanted this to default to the application name. The problem
+                    %% is that the type of application that uses cuttlefish is also the kind
+                    %% that doesn't have an .app.src file, so rebar doesn't get it.
+                    %% I could have done something with cwd, but I didn't like that because you
+                    %% could be building anywhere. So, cuttlefish it is. he's pretty cool anyway.
+                    File = rebar_config:get_local(Config, cuttlefish_filename, "cuttlefish.conf"),
+                    Filename = filename:join([TargetDir, "etc", File]),
                     
                     cuttlefish_conf:generate_file(Mappings, Filename),
                     ok;


### PR DESCRIPTION
Fixes #16.

Now you can choo choo choose your config filename.

![choose1](https://f.cloud.github.com/assets/55951/1527507/b5ac1f66-4bf6-11e3-8708-35bf41f09e7c.jpg)

please merge https://github.com/basho/riak/pull/435 and https://github.com/basho/riak_ee/pull/192 first
