### PR TITLE
Better error printing from the rebar plugin

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -298,16 +298,15 @@ engage_cuttlefish(ParsedArgs) ->
 
     case FinalConfig of 
         {error, _X} ->
-            stop_deactivate();
+            error;
         _ ->
-            ok
-    end,
-    FinalAppConfig = proplists:delete(vm_args, FinalConfig), 
-    FinalVMArgs = cuttlefish_vmargs:stringify(proplists:get_value(vm_args, FinalConfig)),
+            FinalAppConfig = proplists:delete(vm_args, FinalConfig), 
+            FinalVMArgs = cuttlefish_vmargs:stringify(proplists:get_value(vm_args, FinalConfig)),
 
-    file:write_file(Destination,io_lib:fwrite("~p.\n",[FinalAppConfig])),
-    file:write_file(DestinationVMArgs, io_lib:fwrite(string:join(FinalVMArgs, "\n"), [])),
-    {Destination, DestinationVMArgs}.
+            file:write_file(Destination,io_lib:fwrite("~p.\n",[FinalAppConfig])),
+            file:write_file(DestinationVMArgs, io_lib:fwrite(string:join(FinalVMArgs, "\n"), [])),
+            {Destination, DestinationVMArgs}
+    end.
 
 -spec check_existence(string(), string()) -> {boolean(), string()}.
 check_existence(EtcDir, Filename) ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -296,6 +296,12 @@ engage_cuttlefish(ParsedArgs) ->
             NewConfig
     end, 
 
+    case FinalConfig of 
+        {error, _X} ->
+            stop_deactivate();
+        _ ->
+            ok
+    end,
     FinalAppConfig = proplists:delete(vm_args, FinalConfig), 
     FinalVMArgs = cuttlefish_vmargs:stringify(proplists:get_value(vm_args, FinalConfig)),
 

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -52,7 +52,7 @@ generate(Config0, ReltoolFile) ->
 
                     case cuttlefish_schema:files(Schemas) of 
                         {error, Es} ->
-                            io:format("Error loading schmeas: ~n"),
+                            io:format("Error loading schemas: ~n"),
                             [ io:format("  ~p~n", [E]) || E <- Es];
                         {_Translations, Mappings, _Validators} ->
                             make_default_file(Config, TargetDir, Mappings)

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -51,9 +51,9 @@ generate(Config0, ReltoolFile) ->
                     io:format("Schema: ~p~n", [Schemas]),
 
                     case cuttlefish_schema:files(Schemas) of 
-                        {error, Es} ->
-                            io:format("Error loading schemas: ~n"),
-                            [ io:format("  ~p~n", [E]) || E <- Es];
+                        {error, _Es} ->
+                            %% These errors were already printed
+                            error;
                         {_Translations, Mappings, _Validators} ->
                             make_default_file(Config, TargetDir, Mappings)
                     end;

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -50,18 +50,14 @@ generate(Config0, ReltoolFile) ->
 
                     io:format("Schema: ~p~n", [Schemas]),
 
-                    {_Translations, Mappings, _Validators} = cuttlefish_schema:files(Schemas),
+                    case cuttlefish_schema:files(Schemas) of 
+                        {error, Es} ->
+                            io:format("Error loading schmeas: ~n"),
+                            [ io:format("  ~p~n", [E]) || E <- Es];
+                        {_Translations, Mappings, _Validators} ->
+                            make_default_file(Config, TargetDir, Mappings)
+                    end;
 
-                    %% I really wanted this to default to the application name. The problem
-                    %% is that the type of application that uses cuttlefish is also the kind
-                    %% that doesn't have an .app.src file, so rebar doesn't get it.
-                    %% I could have done something with cwd, but I didn't like that because you
-                    %% could be building anywhere. So, cuttlefish it is. he's pretty cool anyway.
-                    File = rebar_config:get_local(Config, cuttlefish_filename, "cuttlefish.conf"),
-                    Filename = filename:join([TargetDir, "etc", File]),
-                    
-                    cuttlefish_conf:generate_file(Mappings, Filename),
-                    ok;
                 false ->
                     %%io:format("No {overlay, [...]} found in reltool.config.\n", []);
                     ok;
@@ -73,6 +69,18 @@ generate(Config0, ReltoolFile) ->
         no ->
             ok
     end,
+    ok.
+
+make_default_file(Config, TargetDir, Mappings) ->
+    %% I really wanted this to default to the application name. The problem
+    %% is that the type of application that uses cuttlefish is also the kind
+    %% that doesn't have an .app.src file, so rebar doesn't get it.
+    %% I could have done something with cwd, but I didn't like that because you
+    %% could be building anywhere. So, cuttlefish it is. he's pretty cool anyway.
+    File = rebar_config:get_local(Config, cuttlefish_filename, "cuttlefish.conf"),
+    Filename = filename:join([TargetDir, "etc", File]),
+    
+    cuttlefish_conf:generate_file(Mappings, Filename),
     ok.
 
 %% Only run for rel directory

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -85,11 +85,7 @@ file(Filename) ->
     S = unicode:characters_to_list(B, utf8),
     case string(S) of 
         {error, Errors} ->
-            case lager:error("Error parsing schema: ~s", [Filename]) of
-                 {error, lager_not_running} ->
-                    io:format("Error parsing schema: ~s~n", [Filename]);
-                 ok -> ok
-            end,
+            cuttlefish_util:print_error("Error parsing schema: ~s", [Filename]),
             {error, Errors};
         Schema ->
             Schema
@@ -133,17 +129,9 @@ string(S) ->
                     [begin
                         case Desc of
                             [H|_] when is_list(H) ->
-                                [ case lager:error(D) of
-                                    {error, lager_not_running} ->
-                                        io:format(D ++ "~n");
-                                    ok -> ok
-                                end || D <- Desc];
+                                [ cuttlefish_util:print_error(D) || D <- Desc];
                             _ ->
-                                case lager:error(lists:flatten(Desc)) of
-                                    {error, lager_not_running} ->
-                                        io:format(lists:flatten(Desc ++ "~n"));
-                                    ok -> ok
-                                end
+                                cuttlefish_util:print_error(Desc)
                         end
                     end || {error, Desc} <- Errors],
                     {error, Errors}

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -192,6 +192,10 @@ parse_schema(ScannedTokens, CommentTokens, Acc) ->
 parse_schema_tokens(Scanned) -> 
     parse_schema_tokens(Scanned, []).
 
+parse_schema_tokens([], Acc=[Last|_]) ->
+    %% When you've reached the end of file without encountering a dot,
+    %% return the result anyway and let erl_parse produce the error.
+    {element(2, Last), lists:reverse(Acc), []};
 parse_schema_tokens(Scanned, Acc=[{dot, LineNo}|_]) ->
     {LineNo, lists:reverse(Acc), Scanned};
 parse_schema_tokens([H|Scanned], Acc) ->

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -40,13 +40,13 @@ strings(ListOfStrings) ->
     merger(fun cuttlefish_schema:string/1, ListOfStrings).
 
 merger(Fun, ListOfInputs) ->
-    {T, M, V} = lists:foldl(
+    Return = lists:foldl(
         fun(Input, {TranslationAcc, MappingAcc, ValidatorAcc}) ->
 
             case Fun(Input) of
-                {error, _Errors} ->
+                {error, Errors} ->
                     %% These have already been logged. We're not moving forward with this
-                    error; 
+                    {error, Errors}; 
                 {Translations, Mappings, Validators} ->
                     
                     NewMappings = lists:foldr(
@@ -75,7 +75,10 @@ merger(Fun, ListOfInputs) ->
         end, 
         {[], [], []}, 
         ListOfInputs),
-    {lists:reverse(T), lists:reverse(M), lists:reverse(V)}.
+    case Return of
+        {error, Errors} -> {error, Errors};
+        {T, M, V} -> {lists:reverse(T), lists:reverse(M), lists:reverse(V)}
+    end.
 
 -spec file(string()) -> {
     [cuttlefish_translation:translation()], 

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -39,7 +39,9 @@
     tokenize_variable_key/1,
     numerify/1,
     ceiling/1,
-    levenshtein/2]).
+    levenshtein/2,
+    print_error/1,
+    print_error/2]).
 
 %% @doc it's a wrapper for proplists:get_value, a convenience function
 %% for schema writers to not have to use [] notation for varibales
@@ -195,6 +197,16 @@ ceiling(X) ->
         Neg when Neg < 0 -> T;
         Pos when Pos > 0 -> T + 1;
         _ -> T
+    end.
+
+print_error(FormatString, Args) ->
+    print_error(io_lib:format(FormatString, Args)). 
+print_error(String) ->
+    case lager:error("~s", String) of
+        {error, lager_not_running} ->
+            io:format("~s~n", [String]),
+            ok;
+        ok -> ok
     end.
 
 %% Levenshtein code by Adam Lindberg, Fredrik Svensson via

--- a/src/cuttlefish_vmargs.erl
+++ b/src/cuttlefish_vmargs.erl
@@ -10,7 +10,13 @@
 %% @doc turns a proplist into a list of strings suitable for vm.args files
 -spec stringify([{any(), string()}]) -> [string()].
 stringify(VMArgsProplist) ->
-    [ lists:flatten(io_lib:format("~s ~s", [K, V]))  || {K, V} <- VMArgsProplist ].
+    [ stringify_line(K, V) || {K, V} <- VMArgsProplist ].
+
+
+stringify_line(K, V) when is_list(V) ->
+  lists:flatten(io_lib:format("~s ~s", [K, V]));
+stringify_line(K, V) ->
+  lists:flatten(io_lib:format("~s ~w", [K, V])).
 
 -ifdef(TEST).
 


### PR DESCRIPTION
The problem is that cuttlefish assumes that lager is running for its logging.

That's always true, except when running the rebar plugin. Rebar doesn't have lager built in, and I'm not saying that it should. What this PR does is io:format errors IF errors are returned to the rebar_plugin. Any other path assumes they've been lager'd.

Also piggybacked in here a fix for vm_args that are being output as ~s even when they're integers. This is probably the little devil behind #48. In fact, I know it is because, spoiler alert, I've got a fix for that coming too.
