### PR TITLE
Added priority to also count inside files

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -67,7 +67,7 @@ parse_and_command(Args) ->
 %% @doc main method for generating erlang term config files
 main(Args) ->
     application:load(lager),
-    
+
     {Command, ParsedArgs, Extra} = parse_and_command(Args),
 
     SuggestedLogLevel = list_to_atom(proplists:get_value(log_level, ParsedArgs)),
@@ -84,7 +84,7 @@ main(Args) ->
     case Command of
         help ->
             print_help();
-        generate -> 
+        generate ->
             generate(ParsedArgs);
         effective ->
             effective(ParsedArgs);
@@ -110,8 +110,8 @@ effective(ParsedArgs) ->
             _:_ ->
                 %% I hate that I had to do this, 'cause you know...
                 %% Erlang and Strings, but actually this is ok because
-                %% sometimes there are going to be weird tuply things 
-                %% in here, so always good to fall back on ~p. 
+                %% sometimes there are going to be weird tuply things
+                %% in here, so always good to fall back on ~p.
                 %% honestly, I think this try should be built into io:format
                 ?STDOUT("~s = ~p", [Variable, Value])
         end
@@ -133,13 +133,13 @@ describe(ParsedArgs, Query) when is_list(Query) ->
 
 
      Results = lists:filter(
-        fun(X) -> 
+        fun(X) ->
             cuttlefish_util:fuzzy_variable_match(QDef, cuttlefish_mapping:variable(X))
-        end, 
+        end,
         Mappings),
 
     case length(Results) of
-        0 -> 
+        0 ->
             ?STDOUT("Variable '~s' not found", [Q]);
         _X ->
             Match = hd(Results),
@@ -206,7 +206,7 @@ generate(ParsedArgs) ->
     end.
 
 load_schema(ParsedArgs) ->
-    SchemaDir = proplists:get_value(schema_dir, ParsedArgs), 
+    SchemaDir = proplists:get_value(schema_dir, ParsedArgs),
 
     SchemaDirFiles = case SchemaDir of
         undefined -> [];
@@ -215,12 +215,12 @@ load_schema(ParsedArgs) ->
     IndividualSchemaFiles = proplists:get_all_values(schema_file, ParsedArgs),
     SchemaFiles = SchemaDirFiles ++ IndividualSchemaFiles,
 
-    SortedSchemaFiles = lists:sort(fun(A,B) -> A > B end, SchemaFiles), 
+    SortedSchemaFiles = lists:sort(fun(A,B) -> A > B end, SchemaFiles),
     case length(SortedSchemaFiles) of
         0 ->
             lager:debug("No Schema files found in specified", []),
             stop_deactivate();
-        _ -> 
+        _ ->
             lager:debug("SchemaFiles: ~p", [SortedSchemaFiles])
     end,
 
@@ -250,8 +250,8 @@ engage_cuttlefish(ParsedArgs) ->
             DP = proplists:get_value(dest_dir, ParsedArgs),
             case filelib:ensure_dir(filename:join(DP, "weaksauce.dummy")) of
                 %% filelib:ensure_dir/1 requires a dummy filename in the argument,
-                %% I think that is weaksauce, hence "weaksauce.dummy" 
-                ok -> 
+                %% I think that is weaksauce, hence "weaksauce.dummy"
+                ok ->
                     DP;
                 {error, E} ->
                     lager:info("Unable to create directory ~s - ~p.  Please check permissions.", [DP, E]),
@@ -273,7 +273,7 @@ engage_cuttlefish(ParsedArgs) ->
     DestinationVMArgs = filename:join(AbsPath, DestinationVMArgsFilename),
 
     lager:debug("Generating config in: ~p", [Destination]),
-    
+
     Schema = load_schema(ParsedArgs),
 
     Conf = load_conf(ParsedArgs),
@@ -290,17 +290,17 @@ engage_cuttlefish(ParsedArgs) ->
                     lager:error("Error parsing advanced.config: ~p", [Error]),
                     stop_deactivate()
             end;
-            
+
         _ ->
             %% Nothing to see here, these aren't the droids you're looking for.
             NewConfig
-    end, 
+    end,
 
-    case FinalConfig of 
+    case FinalConfig of
         {error, _X} ->
             error;
         _ ->
-            FinalAppConfig = proplists:delete(vm_args, FinalConfig), 
+            FinalAppConfig = proplists:delete(vm_args, FinalConfig),
             FinalVMArgs = cuttlefish_vmargs:stringify(proplists:get_value(vm_args, FinalConfig)),
 
             file:write_file(Destination,io_lib:fwrite("~p.\n",[FinalAppConfig])),

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -37,7 +37,7 @@
         doc = [] :: list(),
         include_default = undefined :: string() | undefined,
         validators = [] :: [string()],
-        priority = 0 :: integer()
+        priority = {0, undefined} :: integer()
     }).
 
 -type mapping() :: #mapping{}.
@@ -46,7 +46,8 @@
 -export([
     parse/1,
     is_mapping/1,
-    set_priority/2,
+    set_file_priority/2,
+    set_global_priority/2,
     priority/1,
     variable/1,
     mapping/1,
@@ -87,14 +88,18 @@ parse({mapping, Variable, Mapping, Proplist}) ->
         datatype = Datatype,
         doc = proplists:get_value(doc, Proplist, []),
         include_default = proplists:get_value(include_default, Proplist),
-        validators = proplists:get_value(validators, Proplist, [])
+        validators = proplists:get_value(validators, Proplist, []),
+        priority = {0, proplists:get_value(priority, Proplist, undefined)}
     };
 parse(X) -> {error, io_lib:format("poorly formatted input to cuttlefish_mapping:parse/1 : ~p", [X])}.
 
+-spec set_global_priority(mapping(), Priority::integer()) -> mapping().
+set_global_priority(Mapping = #mapping{priority = {_, F}}, Prio) ->
+    Mapping#mapping{priority = {Prio, F}}.
 
--spec set_priority(mapping(), Priority::integer()) -> mapping().
-set_priority(Mapping, Prio) ->
-    Mapping#mapping{priority = Prio}.
+-spec set_file_priority(mapping(), Priority::integer()) -> mapping().
+set_file_priority(Mapping = #mapping{priority = {G, _}}, Prio) ->
+    Mapping#mapping{priority = {G, Prio}}.
 
 -spec priority(mapping()) -> integer().
 priority(#mapping{priority = P}) ->

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -29,14 +29,15 @@
 -record(translation, {
     mapping::string(),
     func::fun(),
-    priority = 0 :: integer()
+    priority = {0, 0} :: integer()
     }).
 -type translation() :: #translation{}.
 -export_type([translation/0]).
 
 -export([
     parse/1,
-    set_priority/2,
+    set_file_priority/2,
+    set_global_priority/2,
     priority/1,
     is_translation/1,
     mapping/1,
@@ -53,9 +54,13 @@ parse({translation, Mapping, Fun}) ->
 parse(X) -> {error, io_lib:format("poorly formatted input to cuttlefish_translation:parse/1 : ~p", [X])}.
 
 
--spec set_priority(translation(), Priority::integer()) -> translation().
-set_priority(Translation, Prio) ->
-    Translation#translation{priority = Prio}.
+-spec set_global_priority(translation(), Priority::integer()) -> translation().
+set_global_priority(Translation = #translation{priority = {_, F}}, Prio) ->
+    Translation#translation{priority = {Prio, F}}.
+
+-spec set_file_priority(translation(), Priority::integer()) -> translation().
+set_file_priority(Translation = #translation{priority = {G, _}}, Prio) ->
+    Translation#translation{priority = {G, Prio}}.
 
 -spec priority(translation()) -> integer().
 priority(#translation{priority = P}) ->

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -28,15 +28,18 @@
 
 -record(translation, {
     mapping::string(),
-    func::fun()
+    func::fun(),
+    priority = 0 :: integer()
     }).
 -type translation() :: #translation{}.
 -export_type([translation/0]).
 
 -export([
     parse/1,
+    set_priority/2,
+    priority/1,
     is_translation/1,
-    mapping/1, 
+    mapping/1,
     func/1,
     replace/2,
     remove_duplicates/1]).
@@ -50,6 +53,14 @@ parse({translation, Mapping, Fun}) ->
 parse(X) -> {error, io_lib:format("poorly formatted input to cuttlefish_translation:parse/1 : ~p", [X])}.
 
 
+-spec set_priority(translation(), Priority::integer()) -> translation().
+set_priority(Translation, Prio) ->
+    Translation#translation{priority = Prio}.
+
+-spec priority(translation()) -> integer().
+priority(#translation{priority = P}) ->
+    P.
+
 -spec is_translation(any()) -> boolean().
 is_translation(T) -> is_tuple(T) andalso element(1, T) =:= translation.
 
@@ -61,7 +72,7 @@ func(T)     -> T#translation.func.
 
 -spec replace(translation(), [translation()]) -> [translation()].
 replace(Translation, ListOfTranslations) ->
-    Removed = lists:filter(fun(T) -> mapping(T) =/= mapping(Translation) end, ListOfTranslations), 
+    Removed = lists:filter(fun(T) -> mapping(T) =/= mapping(Translation) end, ListOfTranslations),
     Removed ++ [Translation].
 
 -spec remove_duplicates([translation()]) -> [translation()].
@@ -69,9 +80,9 @@ remove_duplicates(Translations) ->
     lists:foldl(
         fun(Translation, Acc) ->
             replace(Translation, Acc)
-        end, 
-        [], 
-        Translations). 
+        end,
+        [],
+        Translations).
 
 -ifdef(TEST).
 

--- a/test/order_test/etc/test.conf
+++ b/test/order_test/etc/test.conf
@@ -1,0 +1,7 @@
+00.setting.A = a0
+00.setting.B = b0
+00.setting.C = c0
+
+01.setting.A = a1
+01.setting.B = b1
+01.setting.C = c1

--- a/test/order_test/schema/00.schema
+++ b/test/order_test/schema/00.schema
@@ -1,0 +1,17 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+{mapping, "00.setting.A", "app.setting.a", []}.
+{mapping, "00.setting.B", "app.setting.b", []}.
+{mapping, "00.setting.C", "app.setting.t2", []}.
+
+{translation,
+ "app.setting.c",
+ fun(Conf) ->
+         "t0.c"
+ end}.
+
+{translation,
+ "app.setting.t1",
+ fun(Conf) ->
+         "t0.1"
+ end}.

--- a/test/order_test/schema/01.schema
+++ b/test/order_test/schema/01.schema
@@ -1,0 +1,17 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ft=erlang ts=4 sw=4 et
+{mapping, "01.setting.A", "app.setting.a", []}.
+{mapping, "01.setting.B", "app.setting.b", []}.
+{mapping, "01.setting.C", "app.setting.c", []}.
+
+{translation,
+ "app.setting.t1",
+ fun(Conf) ->
+         "t1.1"
+ end}.
+
+{translation,
+ "app.setting.t2",
+ fun(Conf) ->
+         "t1.2"
+ end}.

--- a/test/order_test/schema/erlang_vm.schema
+++ b/test/order_test/schema/erlang_vm.schema
@@ -1,0 +1,103 @@
+%%% Things that need to be in vm.args, but never tuned
+
+{mapping, "erlang.smp", "vm_args.-smp", [
+  {default, "enable"},
+  {level, advanced}
+]}.
+
+{mapping, "erlang.W", "vm_args.+W", [
+  {default, "w"},
+  {level, advanced}
+]}.
+
+{mapping, "erlang.K", "vm_args.+K", [
+  {default, "true"},
+  {level, advanced}
+]}.
+
+%%%% Tunables
+%% @doc Name of the riak node
+{mapping, "nodename", "vm_args.-name", [
+  {default, "{{node}}"}
+]}. 
+
+%% @doc Cookie for distributed node communication.  All nodes in the same cluster
+%% should use the same cookie or they will not be able to communicate.
+{mapping, "distributed_cookie", "vm_args.-setcookie", [
+  {default, "erlang"}
+]}.
+
+{mapping, "erlang.async_threads", "vm_args.+A", [
+  {default, "64"}
+]}.
+
+%% @doc Increase number of concurrent ports/sockets
+{mapping, "erlang.max_ports", "vm_args.-env ERL_MAX_PORTS", [
+  {default, "64000"}
+]}.
+
+%% @doc Tweak GC to run more often 
+{mapping, "erlang.fullsweep_after", "vm_args.-env ERL_FULLSWEEP_AFTER", [
+  {default, "0"},
+  {level, advanced}
+]}.
+
+%% @doc Set the location of crash dumps
+{mapping, "erlang.crash_dump", "vm_args.-env ERL_CRASH_DUMP", [
+  {default, "{{crash_dump}}"}
+]}.
+
+%% @doc Raise the ETS table limit
+{mapping, "erlang.max_ets_tables", "vm_args.-env ERL_MAX_ETS_TABLES", [
+  {default, "256000"}
+]}.
+
+%% @doc Raise the default erlang process limit 
+{mapping, "erlang.process_limit", "vm_args.+P", [
+  {datatype, integer},
+  {default, 256000}
+]}.
+
+{translation, "vm_args.+P", 
+fun(Conf) -> 
+  Procs = cuttlefish_util:conf_get_value("erlang.process_limit", Conf),
+  integer_to_list(Procs)
+end}.
+
+%% @doc For nodes with many busy_dist_port events, Basho recommends
+%% raising the sender-side network distribution buffer size.
+%% 32MB may not be sufficient for some workloads and is a suggested
+%% starting point.
+%% The Erlang/OTP default is 1024 (1 megabyte).
+%% See: http://www.erlang.org/doc/man/erl.html#%2bzdbbl
+{mapping, "erlang.zdbbl", "vm_args.+zdbbl", [
+  {datatype, bytesize},
+  {commented, "32MB"},
+  {validators, ["zdbbl_range"]}
+]}.
+
+{translation, "vm_args.+zdbbl",
+ fun(Conf) -> 
+  ZDBBL = cuttlefish_util:conf_get_value("erlang.zdbbl", Conf, undefined),
+  case ZDBBL of
+    undefined -> undefined;
+    X when is_integer(X) -> cuttlefish_util:ceiling(X / 1024); %% Bytes to Kilobytes;
+    _ -> undefined
+  end
+ end
+}.
+
+{validator, "zdbbl_range", "+zddbl must be between 1KB and 2097151KB", 
+ fun(ZDBBL) -> 
+  %% 2097151KB = 2147482624
+  ZDBBL >= 1024 andalso ZDBBL =< 2147482624
+ end
+}.
+
+%% @doc Erlang VM scheduler tuning.
+%% Prerequisite: a patched VM from Basho, or a VM compiled separately
+%% with this patch applied:
+%%     https://gist.github.com/evanmcc/a599f4c6374338ed672e
+{mapping, "erlang.sfwi", "vm_args.+sfwi", [
+  {commented, "500"}
+]}.


### PR DESCRIPTION
This is a extension of the file order patch. It extends the priority system to within files with the following rules:

The first element of a file has the highest priority, the last element has the lowest one (namely 0). Also mappings can get a `{priority, X}` setting passed that overwrites this automatic rule to force a mapping to have a specific position inside a file, this comes in handy to decouple position in the generated `.conf` file from the priority of a setting withn a file.

In file priorities take a lower impact then the permissions assigned by the file order, this prevent schema orders to mess with other schemas. (i.e. everything in `00.schema` will always have a higher priority then `01.schema`).
# WARNING

This breaks some of the current behavior as it seems that as of this moment the last element in `.schema` to have the highest priority. I left the test failing to point this out.

Other then that I think the new behavior is more sensible since in other places the 'first has higher priority' is already working this way (i.e. the `00.schema` lads first in the `.config` etc.)
