### PR TITLE
Addresses ordering/priority of schemas and elements

### DIFF
--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -129,8 +129,13 @@ validators(M, Validators) ->
 
 -spec replace(mapping(), [mapping()]) -> [mapping()].
 replace(Mapping, ListOfMappings) ->
-    Removed = lists:filter(fun(M) -> variable(M) =/= variable(Mapping) end, ListOfMappings), 
-    Removed ++ [Mapping].
+    Exists = lists:keymember(variable(Mapping), #mapping.variable, ListOfMappings),
+    case Exists of
+        true ->
+            lists:keyreplace(variable(Mapping), #mapping.variable, ListOfMappings, Mapping);
+        _ ->
+            [Mapping | ListOfMappings]
+    end.
 
 -spec remove_duplicates([mapping()]) -> [mapping()].
 remove_duplicates(Mappings) ->
@@ -199,19 +204,6 @@ replace_test() ->
     }),
 
     SampleMappings = [Element1,
-    parse({
-        mapping,
-        "conf.key",
-        "erlang.key1",
-        [
-            {level, advanced},
-            {default, "default value"},
-            {datatype, {enum, [on, off]}},
-            {commented, "commented value"},
-            {include_default, "default_substitution"},
-            {doc, ["documentation", "for feature"]}
-        ]
-    }),
     parse({
         mapping,
         "conf.key",

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -61,8 +61,13 @@ func(T)     -> T#translation.func.
 
 -spec replace(translation(), [translation()]) -> [translation()].
 replace(Translation, ListOfTranslations) ->
-    Removed = lists:filter(fun(T) -> mapping(T) =/= mapping(Translation) end, ListOfTranslations), 
-    Removed ++ [Translation].
+    Exists = lists:keymember(mapping(Translation), #translation.mapping, ListOfTranslations),
+    case Exists of
+        true ->
+            lists:keyreplace(mapping(Translation), #translation.mapping, ListOfTranslations, Translation);
+        _ ->
+            [Translation | ListOfTranslations]
+    end.
 
 -spec remove_duplicates([translation()]) -> [translation()].
 remove_duplicates(Translations) ->
@@ -110,10 +115,6 @@ replace_test() ->
     },
 
     SampleTranslations = [Element1,
-    #translation{
-        mapping = "mapping1",
-        func = fun(X) -> X*3 end
-    },
     #translation{
         mapping = "mapping1",
         func = fun(X) -> X*4 end

--- a/src/cuttlefish_validator.erl
+++ b/src/cuttlefish_validator.erl
@@ -67,8 +67,13 @@ func(V) -> V#validator.func.
 
 -spec replace(validator(), [validator()]) -> [validator()].
 replace(Validator, ListOfValidators) ->
-    Removed = lists:filter(fun(T) -> name(T) =/= name(Validator) end, ListOfValidators), 
-    Removed ++ [Validator].
+    Exists = lists:keymember(name(Validator), #validator.name, ListOfValidators),
+    case Exists of
+        true ->
+            lists:keyreplace(name(Validator), #validator.name, ListOfValidators, Validator);
+        _ ->
+            [Validator | ListOfValidators]
+    end.
 
 -spec remove_duplicates([validator()]) -> [validator()].
 remove_duplicates(Validators) ->
@@ -121,11 +126,6 @@ replace_test() ->
     },
 
     SampleValidators = [Element1,
-    #validator{
-        name = "name1",
-        description = "description1",
-        func = fun(X) -> X*3 end
-    },
     #validator{
         name = "name1",
         description = "description1",

--- a/test/multi1.schema
+++ b/test/multi1.schema
@@ -1,11 +1,19 @@
-{mapping, "a.b.c", "what.ev1", []}.
-{mapping, "a.b.c", "what.ev2", []}.
-{mapping, "a.b.d", "what.ev1", []}.
-{mapping, "a.b.c", "what.ev3", []}.
+%% We'll say this is the application level schema. This is where the developer
+%% defines their own big config knobs. Also, overrides anything brought in from 
+%% dependencies. That means we can do things like override "a.some.var2"
+%% The original order should be preserved.
+{mapping, "a.some.var2", "app_a.some_var", [
+    {default, "defined!"}
+]}.
 
-{translation, "what.ev1", fun(X) -> 1 end}.
-{translation, "what.ev1", fun(X) -> 2 end}.
-{translation, "what.ev2", fun(X) -> 1 end}.
-{translation, "what.ev1", fun(X) -> 3 end}.
+%% Works for translations too!
+{translation, "app_a.some_var3", fun(X) -> "toplevel" end}.
 
-{validator, "my.little.validator", "has the sweetest... smile", fun(_AlwaysTrue) -> true end}.
+%% And validators!
+{validator, "a.validator2", "so much validator", fun(_AlwaysFalse) -> false end}.
+
+%% But we can have our own mappings too! And they will come cuttlefish_lager_test_backend
+{mapping, "top_level.var1", "app_a.big_var", []}.
+{translation, "app_a.big_var", fun(X) -> "tippedy top" end}.
+{validator, "top.val", "you only validate once.", fun(_AlwaysFalse) -> false end}.
+

--- a/test/multi2.schema
+++ b/test/multi2.schema
@@ -1,3 +1,19 @@
-{mapping, "a.b.c", "what.ev4", []}.
+%% This'll be the 'a' namespace
 
-{translation, "what.ev1", fun(X) -> 4 end}.
+{mapping, "a.some.var1", "app_a.some_var1", []}.
+{translation, "app_a.some_var1", fun(X) -> "a1" end}.
+
+{mapping, "a.some.var2", "app_a.some_var2", []}.
+{translation, "app_a.some_var2", fun(X) -> "a2" end}.
+
+{mapping, "a.some.var3", "app_a.some_var3", []}.
+{translation, "app_a.some_var3", fun(X) -> "a3" end}.
+
+{validator, "a.validator1", "validate! validate!", fun(_AlwaysTrue) -> true end}.
+
+{validator, "a.validator2", "validate! validate!", fun(_AlwaysTrue) -> true end}.
+
+%% In a weird and highly unlikely cross namespace definition. some developer of app A has decided
+%% that they want to override "b.validator2". They can do that here, but it will still occur after
+%% "b.validator2"
+{validator, "b.validator2", "validators are just ok", fun(_AlwaysTrue) -> true end}.

--- a/test/multi3.schema
+++ b/test/multi3.schema
@@ -1,0 +1,17 @@
+%%% We'll call this a 'b' namespace
+
+{mapping, "b.some.var1", "app_b.some_var1", []}.
+{translation, "app_b.some_var1", fun(X) -> "b1" end}.
+
+{mapping, "b.some.var2", "app_b.some_var2", []}.
+{translation, "app_b.some_var2", fun(X) -> "b2" end}.
+
+{validator, "b.validator1", "validators are magic!", fun(_AlwaysFalse) -> false end}.
+{validator, "b.validator2", "validators are magic!", fun(_AlwaysFalse) -> false end}.
+
+%% For some nutty reason, somebody has decided to redefine "b.some.var1" later in the same schema.
+%% This should appear in the same place the original definition above was, but with the new values.
+{mapping, "b.some.var1", "app_b.some_var3", []}.
+%% Same for translations
+{translation, "app_b.some_var1", fun(X) -> "b3" end}.
+


### PR DESCRIPTION
handles the issue in #70 

I've been trying to avoid something like an extra priority flag, like the implementation in #71. This has a more explicit test for the issue described and a fix that works more in the way I originally envisioned.

It also preserves order, so if you override something in your main schema, it still hangs out in the original place defined.

This also builds some groundwork for how we'll eventually handle partial overrides like requested in #68 
