### PR TITLE
Two Mappings walk into a bar... expecting to meet a translation, but he never showed up.

### DIFF
--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -42,10 +42,10 @@ map_add_defaults({_, Mappings, _} = Schema, Config) ->
             lager:info("Error adding defaults, aborting"),
             {error, add_defaults};
         _ -> 
-            map_transform_datatypes(Schema, Config, DConfig)
+            map_transform_datatypes(Schema, DConfig)
     end.
 
-map_transform_datatypes({_, Mappings, _} = Schema, Config, DConfig) ->
+map_transform_datatypes({_, Mappings, _} = Schema, DConfig) ->
     %% Everything in DConfig is of datatype "string", 
     %% transform_datatypes turns them into other erlang terms
     %% based on the schema
@@ -57,20 +57,20 @@ map_transform_datatypes({_, Mappings, _} = Schema, Config, DConfig) ->
             lager:info("Error transforming datatypes, aborting"),
             {error, transform_datatypes};
         _ ->
-            map_validate(Schema, Config, Conf)
+            map_validate(Schema, Conf)
     end.
 
-map_validate(Schema, Config, Conf) ->
+map_validate(Schema, Conf) ->
     %% Any more advanced validators
     lager:info("Validation"),
     case run_validations(Schema, Conf) of
-        true -> map_translate(Schema, Config, Conf);
+        true -> map_translate(Schema, Conf);
         _ ->
             lager:error("Some validator failed, aborting"),
             {error, validation}
     end.
 
-map_translate({Translations, Mappings, _Validators} = Schema, _Config, Conf) ->
+map_translate({Translations, Mappings, _Validators} = Schema, Conf) ->
     %% This fold handles 1:1 mappings, that have no cooresponding translations
     %% The accumlator is the app.config proplist that we start building from
     %% these 1:1 mappings, hence the return "DirectMappings". 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -80,7 +80,7 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     %% if a user didn't actually configure this setting in the .conf file and 
     %% there's no default in the schema, then there won't be enough information
     %% during the translation phase to succeed, so we'll earmark it to be skipped
-    {DirectMappings, {TranslationsToMaybeDrop, TranslationsToKeep}} = lists:foldl(
+    {DirectMappings, {TranslationsToMaybeDrop, TranslationsToKeep}} = lists:foldr(
         fun(MappingRecord, {ConfAcc, {MaybeDrop, Keep}}) ->
             Mapping = cuttlefish_mapping:mapping(MappingRecord),
             Default = cuttlefish_mapping:default(MappingRecord),

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -84,7 +84,6 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
         fun(MappingRecord, {ConfAcc, {MaybeDrop, Keep}}) ->
             Mapping = cuttlefish_mapping:mapping(MappingRecord),
             Default = cuttlefish_mapping:default(MappingRecord),
-            io:format("Default: ~p~n", [Default]),
             Variable = cuttlefish_mapping:variable(MappingRecord),
             case {
                 Default =/= undefined orelse cuttlefish_conf:is_variable_defined(Variable, Conf), 

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -56,8 +56,12 @@
     replace/2,
     remove_duplicates/1,
     validators/1,
-    validators/2
+    validators/2,
+    record_index/1
     ]).
+
+record_index(mapping) -> #mapping.mapping;
+record_index(_Other) -> error.
 
 -spec parse({mapping, string(), string(), [{atom(), any()}]}) -> mapping() | {error, list()}.
 parse({mapping, Variable, Mapping, Proplist}) ->

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -57,11 +57,8 @@
     remove_duplicates/1,
     validators/1,
     validators/2,
-    record_index/1
+    remove_all_but_first/2
     ]).
-
-record_index(mapping) -> #mapping.mapping;
-record_index(_Other) -> error.
 
 -spec parse({mapping, string(), string(), [{atom(), any()}]}) -> mapping() | {error, list()}.
 parse({mapping, Variable, Mapping, Proplist}) ->
@@ -149,6 +146,19 @@ remove_duplicates(Mappings) ->
         end, 
         [], 
         Mappings). 
+
+-spec remove_all_but_first(string(), [mapping()]) -> [mapping()].
+remove_all_but_first(MappingName, Mappings) ->
+    remove_all_but_first(MappingName, [], Mappings).
+remove_all_but_first(_, AlreadyChecked, []) -> AlreadyChecked;
+remove_all_but_first(MappingName, AlreadyChecked, [M|Mappings]) ->
+    case cuttlefish_mapping:mapping(M) =:= MappingName of
+        true ->
+            AlreadyChecked 
+            ++ [M|lists:keydelete(MappingName, #mapping.mapping, Mappings)];
+        false ->
+            remove_all_but_first(MappingName, AlreadyChecked ++ [M], Mappings)
+    end.
 
 -ifdef(TEST).
 

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -149,17 +149,12 @@ remove_duplicates(Mappings) ->
 
 -spec remove_all_but_first(string(), [mapping()]) -> [mapping()].
 remove_all_but_first(MappingName, Mappings) ->
-    remove_all_but_first(MappingName, [], Mappings).
-remove_all_but_first(_, AlreadyChecked, []) -> AlreadyChecked;
-remove_all_but_first(MappingName, AlreadyChecked, [M|Mappings]) ->
-    case cuttlefish_mapping:mapping(M) =:= MappingName of
-        true ->
-            AlreadyChecked 
-            ++ [M|lists:keydelete(MappingName, #mapping.mapping, Mappings)];
-        false ->
-            remove_all_but_first(MappingName, AlreadyChecked ++ [M], Mappings)
-    end.
-
+    lists:foldr(
+        fun(#mapping{mapping=MN}=M, Acc) when MN =:= MappingName->
+                [M|lists:keydelete(MN, #mapping.mapping, Acc)];
+            (M, Acc) ->
+                [M|Acc]
+        end, [], Mappings).
 -ifdef(TEST).
 
 mapping_test() ->

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -44,7 +44,7 @@ generate(Config0, ReltoolFile) ->
                         end, 
                         Overlays), 
 
-                    Schemas = lists:sort(fun(A,B) -> filename:basename(A) > filename:basename(B) end, [
+                    Schemas = lists:sort([
                         lists:flatten(filename:join(TargetDir, element(3, Schema)))
                     || Schema <- SchemaOverlays]),
 

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -22,7 +22,7 @@
 
 -module(cuttlefish_schema).
 
--export([files/1, file/1, strings/1, string/1]).
+-export([files/1, strings/1]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -34,13 +34,13 @@
 -export_type([schema/0]).
 
 files(ListOfSchemaFiles) ->
-    merger(fun cuttlefish_schema:file/1, ListOfSchemaFiles).
+    merger(fun file/1, ListOfSchemaFiles).
 
 strings(ListOfStrings) ->
-    merger(fun cuttlefish_schema:string/1, ListOfStrings).
+    merger(fun string/1, ListOfStrings).
 
 merger(Fun, ListOfInputs) ->
-    lists:foldr(
+    Schema = lists:foldr(
         fun(Input, {TranslationAcc, MappingAcc, ValidatorAcc}) ->
 
             case Fun(Input) of
@@ -68,10 +68,54 @@ merger(Fun, ListOfInputs) ->
             end 
         end, 
         {[], [], []}, 
-        ListOfInputs).
+        ListOfInputs),
+    filter(Schema).
+
+filter({Translations, Mappings, Validators}) ->
+    Counts = count_mappings(Mappings),
+    {MappingsToCheck, _} = lists:unzip(Counts),
+    NewMappings = lists:foldl(
+        fun(MappingName, Acc) ->
+            case lists:any(
+                fun(T) -> cuttlefish_translation:mapping(T) =:= MappingName end, 
+                Translations) of
+                false ->
+                    remove_all_but_first(MappingName, Acc);
+                _ -> Acc
+            end
+        end,
+        Mappings, MappingsToCheck),
+
+    {Translations, NewMappings, Validators}.
+
+count_mappings(Mappings) ->
+    count_mappings(Mappings, []).
+count_mappings([], Acc) ->
+    Acc;
+count_mappings([M|Mappings], Acc) ->
+    {K, Count, Acc2} = case lists:keyfind(cuttlefish_mapping:mapping(M), 1, Acc) of
+        {Key, C} ->
+            {Key, C, Acc};
+        _ ->
+            {cuttlefish_mapping:mapping(M), 0, Acc ++ [{cuttlefish_mapping:mapping(M), 0}]}
+    end,
+    count_mappings(Mappings, lists:keyreplace(K, 1, Acc2, {K, Count + 1})).
+
+remove_all_but_first(MappingName, Mappings) ->
+    remove_all_but_first(MappingName, [], Mappings).
+remove_all_but_first(_, AlreadyChecked, []) -> AlreadyChecked;
+remove_all_but_first(MappingName, AlreadyChecked, [M|Mappings]) ->
+    case cuttlefish_mapping:mapping(M) =:= MappingName of
+        true ->
+            AlreadyChecked 
+            ++ [M] 
+            ++ lists:keydelete(MappingName, cuttlefish_mapping:record_index(mapping), Mappings);
+        false ->
+            remove_all_but_first(MappingName, AlreadyChecked ++ [M], Mappings)
+    end.
 
 -spec file(string()) -> {
-    [cuttlefish_translation:translation()], 
+    [cuttlefish_translation:translation()],
     [cuttlefish_mapping:mapping()],
     [cuttlefish_validator:validator()]
 } | errorlist().
@@ -391,6 +435,24 @@ files_test() ->
     AssertVal("b.validator1", V4, false),
     AssertVal("b.validator2", V5, true),
 
+    ok.
+
+strings_filtration_test() ->
+
+    String = "{mapping, \"a.b\", \"e.k\", []}.\n"
+          ++ "{mapping, \"a.c\", \"e.k\", []}.\n"
+          ++ "{mapping, \"a.d\", \"e.j\", []}.\n"
+          ++ "{mapping, \"a.e\", \"e.j\", []}.\n"
+          ++ "{translation, \"e.j\", fun(X) -> \"1\" end}.\n"
+          ++ "{mapping, \"b.a\", \"e.i\", []}.\n"
+          ++ "{mapping, \"b.b\", \"e.i\", []}.\n"
+          ++ "{mapping, \"b.c\", \"e.i\", []}.\n"
+          ++ "{translation, \"e.i\", fun(X) -> \"1\" end}.\n",
+    {Translations, Mappings, _} = strings([String]),
+    ?assertEqual(2, length(Translations)),
+    ?assertEqual(6, length(Mappings)),
+    ?assertEqual(["a", "b"], cuttlefish_mapping:variable(hd(Mappings))),
+    ?assertEqual(["b", "b"], cuttlefish_mapping:variable(lists:nth(5, Mappings))),
     ok.
 
 -endif.

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -62,6 +62,7 @@ all_the_marbles_test() ->
 multibackend_test() ->
     lager:start(),
     Schema = cuttlefish_schema:files(["../test/riak.schema", "../test/multi_backend.schema"]),
+
     Conf = [
         {["storage_backend"], "multi"},
         {["multi_backend","bitcask_mult","storage_backend"], "bitcask"},
@@ -79,7 +80,7 @@ multibackend_test() ->
     Multi = proplists:get_value(multi_backend, KV), 
 
     {<<"bitcask_mult">>, riak_kv_bitcask_backend, BitcaskProps} = lists:keyfind(<<"bitcask_mult">>, 1, Multi),
-    io:format("BitcaskProps: ~p~n", [BitcaskProps]), 
+    lager:info("BitcaskProps: ~p", [BitcaskProps]),
     ?assertEqual("/path/to/dat/cask", proplists:get_value(data_root, BitcaskProps)), 
     ?assertEqual(4,                   proplists:get_value(open_timeout, BitcaskProps)),
     ?assertEqual(2147483648,          proplists:get_value(max_file_size, BitcaskProps)),


### PR DESCRIPTION
Here's the problem. You defined two mappings with different variable names, but you had them map to the same erlang variable. This is actually pretty easy to encounter.

Say you've included yokozuna in your application, but you hate the `yokozuna` namespace, so you add another mapping like this:

``` erlang
%% @doc The enabled Yokozuna set this 'on'.
{mapping, "search", "yokozuna.enabled", [
  {default, off},
  {datatype, {enum, [on, off]}}
]}.
```

Now you think you can do this in your conf file: `search = on` but you can't because the existing yokozuna mapping will overwrite it. The previous version of the logic for this was great at comparing "search" to other things called "search" but lousy at looking for multiple things that map to "yokozuna.enabled". Of course, it's never that simple. Sometimes you want lots of different things mapping to one erlang setting, because you're using a translation to take multiple conf values in and turn them into one erlang setting.

This PR alters the logic in the following ways:
1. process mappings in reverse order, so if you do have two, the one that comes in the beginning of the will process last, and overwrite the first one. So, at least the scenario above would work.
2. After schemas are read in, we'll look for any case where more than one mapping maps to a specific erlang variable. The ones that do AND don't have a corresponding translation will have all but the first occurring mapping removed.

Both of these solve the same problem in different ways, but together present a robust solution.
