### PR TITLE
Smart Merge

### DIFF
--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -109,10 +109,8 @@ parse_and_merge({mapping, Variable, _Mapping, Props} = MappingSource, Mappings) 
         OldMapping ->
             MaybeMergedMapping = case proplists:is_defined(merge, Props) of
                 true ->
-                    io:format("true!"),
                     merge(MappingSource, OldMapping);
                 _ ->
-                    io:format("false!"),
                     parse(MappingSource)
             end,
             lists:keyreplace(Var, #mapping.variable, Mappings, MaybeMergedMapping) 
@@ -369,7 +367,6 @@ parse_and_merge_test() ->
     ok.
 
 smart_merge_test() ->
-    
     OldM1 = parse({mapping, "thing.to.merge", "some.key", [
             {default, 7}, 
             {datatype, integer}, 


### PR DESCRIPTION
Dat smart merge.

How's it work?

Say you include a schema from a dependency that has a mapping like this:

``` erlang
%% @doc an amazing configuration setting that I promise 
%% will never not have 10 as a sensible default!
{mapping, "variable.a", "erlang.term", [
    {default, 10},
    {datatype, integer}
]}.
```

So, of course, for your application, 10 is a terrible default. Before you would have to copy this whole mapping into your project's schema and just change the default, but now, you can choose a smart merge:

``` erlang
{mapping, "variable.a", "erlang.term", [
    merge,
    {default, 10000}
]}.
```

So wha happen?

well, the actual mapping will have the new default of 10000 _AND_ all other attributes of the original mapping, which in this case means `{datatype, integer}` and importantly, the docs from the original schema will be preserved, so your effective mapping would look like this:

``` erlang
%% @doc an amazing configuration setting that I promise 
%% will never not have 10 as a sensible default!
{mapping, "variable.a", "erlang.term", [
    {default, 10000},
    {datatype, integer}
]}.
```

Unfortunately, as a consequence of choosing to have `mapping` be a 4-tuple, you'll need to provide the erlang mapping (in this case `"erlang.term"`) again. Whatever you put in the 3rd element here **WILL** override the original erlang mapping.
