### PR TITLE
To Kill A Translationbird

### DIFF
--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -87,7 +87,11 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
             Variable = cuttlefish_mapping:variable(MappingRecord),
             case {
                 Default =/= undefined orelse cuttlefish_conf:is_variable_defined(Variable, Conf),
-                lists:any(fun(T) -> cuttlefish_translation:mapping(T) =:= Mapping end, Translations)
+                lists:any(
+                    fun(T) ->
+                        cuttlefish_translation:mapping(T) =:= Mapping
+                    end,
+                    Translations)
                 } of
                 {true, false} ->
                     Tokens = string:tokens(Mapping, "."),

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -28,11 +28,11 @@
 
 -record(translation, {
     mapping::string(),
-    func::fun()
+    func = fun(X) -> X end::fun()
     }).
 -type translation() :: #translation{}.
 -type translation_fun() :: fun(([proplists:property()]) -> any()).
--type raw_translation() :: {translation, string(), translation_fun()}.
+-type raw_translation() :: {translation, string(), translation_fun()} | {translation, string()}.
 -export_type([translation/0]).
 
 -export([
@@ -44,6 +44,10 @@
     replace/2]).
 
 -spec parse(raw_translation()) -> translation() | {error, list()}.
+parse({translation, Mapping}) ->
+    #translation{
+        mapping = Mapping
+    };
 parse({translation, Mapping, Fun}) ->
     #translation{
         mapping = Mapping,
@@ -172,6 +176,19 @@ parse_error_test() ->
     ?assertEqual(
         "poorly formatted input to cuttlefish_translation:parse/1 : not_a_raw_translation",
         lists:flatten(IOList)),
+    ok.
+
+parse_empty_test() ->
+    TranslationDataStruct = {
+        translation,
+        "mapping"
+    },
+
+    Translation = parse(TranslationDataStruct),
+
+    ?assertEqual("mapping", Translation#translation.mapping),
+    F = Translation#translation.func,
+    ?assertEqual(4, F(4)),
     ok.
 
 is_translation_test() ->

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -128,8 +128,18 @@ multibackend_test() ->
     {<<"memory_mult">>, riak_kv_memory_backend, MemProps} = lists:keyfind(<<"memory_mult">>, 1, Multi),
     ?assertEqual(86400, proplists:get_value(ttl, MemProps)),
     ?assertEqual(4096, proplists:get_value(max_memory, MemProps)),
-
     ok.
+
+unset_translation_test() ->
+    lager:start(),
+    Schema = cuttlefish_schema:files(["../test/unset_translation.schema"]),
+    Conf = [
+        {["a", "b"], "8"}
+    ],
+    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    Props = proplists:get_value(erlang, NewConfig),
+    lager:info("~p", [NewConfig]),
+    ?assertEqual(8, proplists:get_value(key, Props)).
 
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -90,7 +90,7 @@
 %
 % * `none` - (default) Lets the operating system manage syncing writes.
 % * `o_sync` - Uses the O_SYNC flag which forces syncs on every write.
-% 
+%
 % * `interval` - Riak will force Bitcask to sync every `bitcask.sync_interval`
 %   `seconds.
 

--- a/test/unset_translation.schema
+++ b/test/unset_translation.schema
@@ -1,0 +1,10 @@
+{mapping, "a.b", "erlang.key", [
+    {datatype, integer}
+]}.
+
+{translation, "erlang.key",
+    fun(Conf) -> cuttlefish_util:conf_get_value("a.b", Conf) * 17 end
+}.
+
+%% nevermind, I don't want this translated.
+{translation, "erlang.key"}.


### PR DESCRIPTION
If for some reason, you are overriding an existing schema with something particular for your project, you may have run into an edge case. If you need to override a translation, you're fine, but if a translation exists and you just need to remove it? You're out of luck... until now!

Now, you can do this:

``` erlang
{translation, 
 "some.key",
 fun(Conf) ->
   %% Do something to something and return translated value
}.

%% Oh no, that won't do at all
{translation, "some.key"}.
```

The second translation removes the first from the list and replaces it with an undefined function. It's important to note that if a third translation was added afterwards, it would override that deletion.
