### PR TITLE
Translation Error Handling

### DIFF
--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -157,16 +157,16 @@ apply_translations({Translations, _, _} = Schema, Conf, DirectMappings, Translat
                     catch
                         %% cuttlefish:conf_get/2 threw not_found
                         throw:not_found ->
-                            {unset};
+                            unset;
                         %% For explicitly throw(unset) in translations
                         throw:unset ->
-                            {unset};
+                            unset;
                         E:R ->
                             {error, io_lib:format("Error running translation for ~s, [~p, ~p].", [Mapping, E, R])}
                     end,
 
                     case Translated of
-                        {unset} ->
+                        unset ->
                             {Acc, Errors};
                         {set, NewValue} ->
                             {set_value(Tokens, Acc, NewValue), Errors};

--- a/src/lager_stderr_backend.erl
+++ b/src/lager_stderr_backend.erl
@@ -165,7 +165,7 @@ console_log_test_() ->
                 application:load(lager),
                 application:set_env(lager, handlers, []),
                 application:set_env(lager, error_logger_redirect, false),
-                application:start(lager),
+                lager:start(),
                 whereis(standard_error)
         end,
         fun(User) ->

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -141,6 +141,13 @@ unset_translation_test() ->
     lager:info("~p", [NewConfig]),
     ?assertEqual(8, proplists:get_value(key, Props)).
 
+not_found_error_test() ->
+    lager:start(),
+    Schema = cuttlefish_schema:files(["../test/throw_not_found.schema"]),
+    Conf = [],
+    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual({error, apply_translations}, NewConfig).
+
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),
     ActualKeys = lists:sort(proplists:get_keys(Actual)),

--- a/test/throw_not_found.schema
+++ b/test/throw_not_found.schema
@@ -1,0 +1,7 @@
+{mapping, "a.b", "c.d", []}.
+{translation,
+ "c.d.",
+ fun(Conf) ->
+    Value = cuttlefish:conf_get("a.b", Conf),
+    Value
+ end}.


### PR DESCRIPTION
Ran into a problem where if a translation threw an error, the 'ok' output from the lager call would actually get inserted into the app.config!

While I was in there, I took another stab at #79.

Right now, it allows you to `throw(unset)` in a translation and have the value not set, so you can add a case statement to check for a value in translations and if it's not there, `throw(unset)`

Future work on that includes creating a `cuttlefish` module for schema writer's API. that will have methods that throw specific errors (e.g. throw:not_found), will get there soon, but this is a simple non-breaking bugfix, so I figured I'd get it out there for review.
