### PR TITLE
Refactorings and More

### DIFF
--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -1,3 +1,4 @@
+%%-*- mode: erlang -*-
 %%% Things that need to be in vm.args, but never tuned
 
 {mapping, "erlang.smp", "vm_args.-smp", [

--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -19,7 +19,7 @@
 %% @doc Name of the riak node
 {mapping, "nodename", "vm_args.-name", [
   {default, "{{node}}"}
-]}. 
+]}.
 
 %% @doc Cookie for distributed node communication.  All nodes in the same cluster
 %% should use the same cookie or they will not be able to communicate.
@@ -36,7 +36,7 @@
   {default, "64000"}
 ]}.
 
-%% @doc Tweak GC to run more often 
+%% @doc Tweak GC to run more often
 {mapping, "erlang.fullsweep_after", "vm_args.-env ERL_FULLSWEEP_AFTER", [
   {default, "0"},
   {level, advanced}
@@ -52,15 +52,15 @@
   {default, "256000"}
 ]}.
 
-%% @doc Raise the default erlang process limit 
+%% @doc Raise the default erlang process limit
 {mapping, "erlang.process_limit", "vm_args.+P", [
   {datatype, integer},
   {default, 256000}
 ]}.
 
-{translation, "vm_args.+P", 
-fun(Conf) -> 
-  Procs = cuttlefish_util:conf_get_value("erlang.process_limit", Conf),
+{translation, "vm_args.+P",
+fun(Conf) ->
+  Procs = cuttlefish:conf_get("erlang.process_limit", Conf),
   integer_to_list(Procs)
 end}.
 
@@ -77,8 +77,8 @@ end}.
 ]}.
 
 {translation, "vm_args.+zdbbl",
- fun(Conf) -> 
-  ZDBBL = cuttlefish_util:conf_get_value("erlang.zdbbl", Conf, undefined),
+ fun(Conf) ->
+  ZDBBL = cuttlefish:conf_get("erlang.zdbbl", Conf, undefined),
   case ZDBBL of
     undefined -> undefined;
     X when is_integer(X) -> cuttlefish_util:ceiling(X / 1024); %% Bytes to Kilobytes;
@@ -87,8 +87,8 @@ end}.
  end
 }.
 
-{validator, "zdbbl_range", "+zddbl must be between 1KB and 2097151KB", 
- fun(ZDBBL) -> 
+{validator, "zdbbl_range", "+zddbl must be between 1KB and 2097151KB",
+ fun(ZDBBL) ->
   %% 2097151KB = 2147482624
   ZDBBL >= 1024 andalso ZDBBL =< 2147482624
  end

--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
     {lager, "2.0.*", {git, "git://github.com/basho/lager.git", {tag, "2.0.1"}}},
-    {neotoma, "1.6.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.6.2"}}},
-    {kvc, ".*", {git, "git://github.com/etrepum/kvc.git", {tag, "v1.3.0"}}}
+    {neotoma, "1.6.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.6.2"}}}
   ]}.
 
 {post_hooks, [{compile, "./rebar escriptize"}]}.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -1,0 +1,63 @@
+%% -------------------------------------------------------------------
+%%
+%%  External functions for schema writers and cuttlefish invokers
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(cuttlefish).
+
+-export([
+    conf_get/2,
+    conf_get/3
+]).
+
+% @doc conf_get/2 is a convenience wrapper for  proplists:get_value/2 for schema
+% writers. Keys to a Conf proplist are variable()s which are a list of strings.
+% This function will look for those, but if you pass it a string() instead, it
+% will be nice and split that string on "." since that's how cuttlefish do.
+% Also, it will  throw(not_found) if the key is not found in the list which is
+% different that  proplists:get_value/2's default behavior of returning
+% 'undefined'. This makes it easy for cuttlefish translations to abort and on
+% error, and not assume a value. If that's what you want, please use conf_get/3.
+% formerly cuttlefish_util:conf_get_value/2
+-spec conf_get(
+        string() | cuttlefish_variable:variable(),
+        cuttlefish_conf:conf()) -> any().
+conf_get([H|_T]=Variable, ConfigProplist) when is_list(H) ->
+    case proplists:is_defined(Variable, ConfigProplist) of
+        true ->
+            proplists:get_value(Variable, ConfigProplist);
+        false ->
+            throw(not_found)
+    end;
+conf_get(Variable, ConfigProplist) ->
+    conf_get(
+      cuttlefish_variable:tokenize(Variable),
+      ConfigProplist).
+
+% @doc conf_get/3 works just like proplists:get_value/3. It expects a variable()
+% as the Key, but is nice enough to take a string() and split it on "."
+% formerly cuttlefish_util:conf_get_value/3
+-spec conf_get(
+        string() | cuttlefish_variable:variable(),
+        cuttlefish_conf:conf(), any()) -> any().
+conf_get([H|_T]=Variable, ConfigProplist, Default) when is_list(H) ->
+    proplists:get_value(Variable, ConfigProplist, Default);
+conf_get(Variable, ConfigProplist, Default) ->
+    conf_get(cuttlefish_variable:tokenize(Variable), ConfigProplist, Default).

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -28,10 +28,9 @@
     files/1,
     is_variable_defined/2]).
 
--type variable() :: [string()].
--type conf_pair() :: {variable(), any()}.
+-type conf_pair() :: {cuttlefish_variable:variable(), any()}.
 -type conf() :: [conf_pair()].
--export_type([conf_pair/0, conf/0, variable/0]).
+-export_type([conf_pair/0, conf/0]).
 
 
 is_variable_defined(VariableDef, Conf) ->

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -31,7 +31,7 @@
 -type variable() :: [string()].
 -type conf_pair() :: {variable(), any()}.
 -type conf() :: [conf_pair()].
--export_type([variable/0, conf_pair/0, conf/0]).
+-export_type([conf_pair/0, conf/0, variable/0]).
 
 
 is_variable_defined(VariableDef, Conf) ->

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -35,7 +35,7 @@
 
 
 is_variable_defined(VariableDef, Conf) ->
-    lists:any(fun({X, _}) -> cuttlefish_util:fuzzy_variable_match(X, VariableDef) end, Conf).
+    lists:any(fun({X, _}) -> cuttlefish_variable:is_fuzzy_match(X, VariableDef) end, Conf).
 
 files(ListOfConfFiles) ->
     lists:foldl(
@@ -96,7 +96,7 @@ generate_element(MappingRecord) ->
     %%    e.g. {include_default, "internal"}
     %%         listener.http.$name -> listener.http.internal
 
-    Field = string:join(cuttlefish_util:variable_match_replace(Key, IncDef), "."),
+    Field = string:join(cuttlefish_variable:replace_match(Key, IncDef), "."),
 
     case generate_element(Level, Default, Commented) of
         no ->

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -1,0 +1,95 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_generator: this is where the action is
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_error).
+
+-type error() :: {error, string()|[string()]}.
+-type errorlist() :: {error, [error()]}.
+-export_type([error/0, errorlist/0]).
+
+-export([
+        contains_error/1,
+        is_error/1,
+        filter/1,
+        errorlist_maybe/1
+]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+-endif.
+
+-spec contains_error(list()) -> boolean().
+contains_error(List) ->
+    lists:any(fun is_error/1, List).
+
+-spec is_error(any()) -> boolean().
+is_error({error, _}) -> true;
+is_error(_) -> false.
+
+-spec filter(list()) -> errorlist().
+filter(List) ->
+    {error, lists:filter(fun is_error/1, List)}.
+
+-spec errorlist_maybe(any()) -> any().
+errorlist_maybe(List) when is_list(List) ->
+    case filter(List) of
+        {error, []} ->
+            List;
+        Errorlist ->
+            Errorlist
+    end;
+errorlist_maybe(AnythingElse) -> AnythingElse.
+
+
+-ifdef(TEST).
+
+is_error_test() ->
+    ?assert(is_error({error, "oh no!"})),
+    ?assert(not(is_error("just an innocent string... I mean a list... I mean... argh, erlang"))),
+    ok.
+
+contains_error_test() ->
+    ?assert(contains_error(["hi", {error, "hi!"}, "bye"])),
+    ?assert(not(contains_error(["hi", "I'm not an error", "bye"]))),
+    ok.
+
+filter_test() ->
+    ?assertEqual({error, []}, filter(["hi", "what even is an error?", "bye"])),
+    ?assertEqual({error, [{error, "etoomanythings"}]},
+                 filter(["hi", {error, "etoomanythings"}, "bye"])),
+    ok.
+
+errorlist_maybe_test() ->
+    ?assertEqual(atom, errorlist_maybe(atom)),
+    ?assertEqual(12, errorlist_maybe(12)),
+    %% Fool you! "string" is a list!, but doesn't contain an error()
+    ?assertEqual("string", errorlist_maybe("string")),
+
+    ?assertEqual(
+       {error, [{error, "etoomanythings"}]},
+       errorlist_maybe(["hi", {error, "etoomanythings"}, "bye"])),
+    ?assertEqual(
+       ["hi", "what even is an error?", "bye"],
+       errorlist_maybe(["hi", "what even is an error?", "bye"])),
+    ok.
+
+-endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -29,7 +29,9 @@
         contains_error/1,
         is_error/1,
         filter/1,
-        errorlist_maybe/1
+        errorlist_maybe/1,
+        print/1,
+        print/2
 ]).
 
 -ifdef(TEST).
@@ -59,6 +61,15 @@ errorlist_maybe(List) when is_list(List) ->
     end;
 errorlist_maybe(AnythingElse) -> AnythingElse.
 
+print(FormatString, Args) ->
+    print(io_lib:format(FormatString, Args)).
+print(String) ->
+    case lager:error("~s", [String]) of
+        {error, lager_not_running} ->
+            io:format("~s~n", [String]),
+            ok;
+        ok -> ok
+    end.
 
 -ifdef(TEST).
 

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -61,8 +61,13 @@ errorlist_maybe(List) when is_list(List) ->
     end;
 errorlist_maybe(AnythingElse) -> AnythingElse.
 
+-spec print(string(), [any()]) -> ok.
 print(FormatString, Args) ->
     print(io_lib:format(FormatString, Args)).
+
+-spec print(string() | error()) -> ok.
+print({error, List}) ->
+    print(lists:flatten(List));
 print(String) ->
     case lager:error("~s", [String]) of
         {error, lager_not_running} ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -134,9 +134,9 @@ describe(ParsedArgs, Query) when is_list(Query) ->
 
      Results = lists:filter(
         fun(X) ->
-            cuttlefish_util:fuzzy_variable_match(QDef, cuttlefish_mapping:variable(X))
-        end,
-        Mappings),
+         cuttlefish_variable:is_fuzzy_match(QDef, cuttlefish_mapping:variable(X))
+       end,
+       Mappings),
 
     case length(Results) of
         0 ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -274,7 +274,13 @@ engage_cuttlefish(ParsedArgs) ->
     Schema = load_schema(ParsedArgs),
 
     Conf = load_conf(ParsedArgs),
-    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    NewConfig = case cuttlefish_generator:map(Schema, Conf) of
+        {error, Phase, {error, Errors}} ->
+            lager:error("Error generating configuration in phase ~s", [Phase]),
+            [ cuttlefish_error:print(E) || E <- Errors],
+            stop_deactivate();
+        ValidConfig -> ValidConfig
+    end,
 
     AdvancedConfigFile = filename:join(EtcDir, "advanced.config"),
     FinalConfig = case filelib:is_file(AdvancedConfigFile) of

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -77,7 +77,7 @@ main(Args) ->
     end,
 
     application:set_env(lager, handlers, [{lager_stderr_backend, LogLevel}]),
-    application:start(lager),
+    lager:start(),
 
     lager:debug("Cuttlefish set to debug level logging"),
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -291,8 +291,8 @@ add_fuzzy_default(Prefixes, Conf, Default, VariableDef) ->
             %% we include the Default value.
             ToAdd = [ {VariableToAdd, Default}
                       || Subst <- Substitutions,
-                         VariableToAdd <- [cuttlefish_util:variable_match_replace(VariableDef, Subst)],
-                         not lists:keymember(VariableToAdd, 1, Conf)],
+                       VariableToAdd <- [cuttlefish_variable:replace_match(VariableDef, Subst)],
+                       not lists:keymember(VariableToAdd, 1, Conf)],
             Conf ++ ToAdd
     end.
 
@@ -319,8 +319,8 @@ get_possible_values_for_fuzzy_matches(Conf, Mappings) ->
                   true ->
                       %% Fuzzy match, extract the matching settings from the conf
                       VD = cuttlefish_mapping:variable(Mapping),
-                      ListOfVars = [ Var || {_, Var } <- cuttlefish_util:matches_for_variable_def(VD, Conf)],
-                      {Prefix, _, _} = cuttlefish_variable:split_variable_on_match(VD),
+                      ListOfVars = [Var || {_, Var} <- cuttlefish_variable:fuzzy_matches(VD, Conf)],
+                      {Prefix, _, _} = cuttlefish_variable:split_on_match(VD),
                       orddict:append_list(Prefix, ListOfVars, FuzzyMatches)
               end
       end,
@@ -382,7 +382,7 @@ find_mapping([H|_]=Variable, Mappings) when is_list(H) ->
     {HardMappings, FuzzyMappings} =  lists:foldl(
         fun(Mapping, {HM, FM}) ->
             VariableDef = cuttlefish_mapping:variable(Mapping),
-            case {Variable =:= VariableDef, cuttlefish_util:fuzzy_variable_match(Variable, VariableDef)} of
+            case {Variable =:= VariableDef, cuttlefish_variable:is_fuzzy_match(Variable, VariableDef)} of
                 {true, _} -> {[Mapping|HM], FM};
                 {_, true} -> {HM, [Mapping|FM]};
                 _ -> {HM, FM}

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -38,7 +38,6 @@ map_add_defaults({_, Mappings, _} = Schema, Config) ->
     %% add_defaults/2 rolls the default values in from the schema
     lager:info("Adding Defaults"),
     DConfig = add_defaults(Config, Mappings),
-
     case contains_error(DConfig) of
         true ->
             lager:info("Error adding defaults, aborting"),
@@ -156,8 +155,10 @@ apply_translations({Translations, _, _} = Schema, Conf, DirectMappings, Translat
                             {set, X}
                     catch
                         %% cuttlefish:conf_get/2 threw not_found
-                        throw:not_found ->
-                            unset;
+                        %% Still deciding what to do here...
+                        %% TODO: Decide!
+                        %% throw:not_found ->
+                        %%     unset;
                         %% For explicitly throw(unset) in translations
                         throw:unset ->
                             unset;
@@ -180,10 +181,12 @@ apply_translations({Translations, _, _} = Schema, Conf, DirectMappings, Translat
         end,
         {DirectMappings, []},
         Translations),
-    lager:info("Applied Translations"),
     case Errorlist of
-        [] -> Proplist;
-        _Es ->
+        [] ->
+            lager:info("Applied Translations"),
+            Proplist;
+        Es ->
+            [lager:error("Error: ~p", [lists:flatten(E)]) || {error, E} <- Es],
             {error, apply_translations}
     end.
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -595,7 +595,7 @@ apply_mappings_test() ->
     ],
 
     {DirectMappings, []} = apply_mappings({[], Mappings, []}, Conf),
-    ?assertEqual("1", kvc:path("erlang.key", DirectMappings)),
+    cuttlefish_unit:assert_config(DirectMappings, "erlang.key", "1"),
     ok.
 
 find_mapping_test() ->

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -339,7 +339,7 @@ get_possible_values_for_fuzzy_matches(Conf, Mappings) ->
 -spec transform_datatypes(
         cuttlefish_conf:conf(),
         [cuttlefish_mapping:mapping()]
-      ) -> {cuttlefish_conf:conf(), cuttlefish_error:errorlist()}.
+      ) -> {cuttlefish_conf:conf(), [cuttlefish_error:error()]}.
 transform_datatypes(Conf, Mappings) ->
     lists:foldl(
         fun({Variable, Value}, {Acc, ErrorAcc}) ->

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -320,7 +320,7 @@ get_possible_values_for_fuzzy_matches(Conf, Mappings) ->
                       %% Fuzzy match, extract the matching settings from the conf
                       VD = cuttlefish_mapping:variable(Mapping),
                       ListOfVars = [ Var || {_, Var } <- cuttlefish_util:matches_for_variable_def(VD, Conf)],
-                      {Prefix, _, _} = cuttlefish_util:split_variable_on_match(VD),
+                      {Prefix, _, _} = cuttlefish_variable:split_variable_on_match(VD),
                       orddict:append_list(Prefix, ListOfVars, FuzzyMatches)
               end
       end,
@@ -400,7 +400,7 @@ find_mapping([H|_]=Variable, Mappings) when is_list(H) ->
         {X, Y} -> {error, lists:flatten(io_lib:format("~p hard mappings and ~p fuzzy mappings found for ~s", [X, Y, string:join(Variable, ".")]))}
     end;
 find_mapping(Variable, Mappings) ->
-    find_mapping(cuttlefish_util:tokenize_variable_key(Variable), Mappings).
+    find_mapping(cuttlefish_variable:tokenize(Variable), Mappings).
 
 run_validations({_, Mappings, Validators}, Conf) ->
     Validations = [ begin

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -79,7 +79,7 @@ parse({mapping, Variable, Mapping, Proplist}) ->
     end,
 
     #mapping{
-        variable = cuttlefish_util:tokenize_variable_key(Variable),
+        variable = cuttlefish_variable:tokenize(Variable),
         default = proplists:get_value(default, Proplist),
         commented = proplists:get_value(commented, Proplist),
         mapping = Mapping,
@@ -106,7 +106,7 @@ parse(X) ->
 -spec parse_and_merge(
     raw_mapping(), [mapping()]) -> [mapping()].
 parse_and_merge({mapping, Variable, _Mapping, Props} = MappingSource, Mappings) ->
-    Var = cuttlefish_util:tokenize_variable_key(Variable),
+    Var = cuttlefish_variable:tokenize(Variable),
     case lists:keyfind(Var, #mapping.variable, Mappings) of
         false ->
             [ parse(MappingSource) | Mappings];

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -29,20 +29,19 @@
 -compile(export_all).
 -endif.
 
--type error() :: {error, string()|[string()]}.
--type errorlist() :: {error, [error()]}.
 -type schema() :: {[cuttlefish_translation:translation()], [cuttlefish_mapping:mapping()], [cuttlefish_validator:validator()]}.
 -export_type([schema/0]).
 
--spec files([string()]) -> schema() | errorlist().
+-spec files([string()]) -> schema() | cuttlefish_error:errorlist().
 files(ListOfSchemaFiles) ->
     merger(fun file/1, ListOfSchemaFiles).
 
--spec strings([string()]) -> schema() | errorlist().
+-spec strings([string()]) -> schema() | cuttlefish_error:errorlist().
 strings(ListOfStrings) ->
     merger(fun string/1, ListOfStrings).
 
--spec merger(fun((string()) -> schema() | errorlist()), [string()]) -> schema() | errorlist().
+-spec merger(fun((string()) -> schema() | cuttlefish_error:errorlist()), [string()]) ->
+                    schema() | cuttlefish_error:errorlist().
 merger(Fun, ListOfInputs) ->
     Schema = lists:foldr(
         fun(Input, {TranslationAcc, MappingAcc, ValidatorAcc}) ->
@@ -79,7 +78,7 @@ merger(Fun, ListOfInputs) ->
 
 %% This filter is *ONLY* for the case of multiple mappings to a single erlang
 %% app setting, *AND* there's no corresponding translation for that app setting
--spec filter(schema() | errorlist()) -> schema() | errorlist().
+-spec filter(schema() | cuttlefish_error:errorlist()) -> schema() | cuttlefish_error:errorlist().
 filter({error, Errorlist}) ->
     {error, Errorlist};
 filter({Translations, Mappings, Validators}) ->
@@ -107,7 +106,7 @@ count_mappings(Mappings) ->
         orddict:new(),
         Mappings).
 
--spec file(string()) -> schema() | errorlist().
+-spec file(string()) -> schema() | cuttlefish_error:errorlist().
 file(Filename) ->
     {ok, B} = file:read_file(Filename),
     %% TODO: Hardcoded utf8
@@ -120,7 +119,7 @@ file(Filename) ->
             Schema
     end.
 
--spec string(string()) -> schema() | errorlist().
+-spec string(string()) -> schema() | cuttlefish_error:errorlist().
 string(S) ->
     case erl_scan:string(S) of
         {ok, Tokens, _} ->
@@ -156,12 +155,12 @@ parse_schema(Tokens, Comments) ->
     {[cuttlefish_translation:translation()],
      [cuttlefish_mapping:mapping()],
      [cuttlefish_validator:validator()],
-     [errorlist()]}
+     [cuttlefish_error:errorlist()]}
     ) ->
         {[cuttlefish_translation:translation()],
          [cuttlefish_mapping:mapping()],
          [cuttlefish_validator:validator()],
-         [errorlist()]}.
+         [cuttlefish_error:errorlist()]}.
 %% We're done! We don't care about any comments after the last schema item
 parse_schema([], _LeftoverComments, {TAcc, MAcc, VAcc, EAcc}) ->
     {lists:reverse(TAcc), lists:reverse(MAcc), lists:reverse(VAcc), lists:reverse(EAcc)};
@@ -207,7 +206,7 @@ parse_schema_tokens(Scanned, Acc=[{dot, LineNo}|_]) ->
 parse_schema_tokens([H|Scanned], Acc) ->
     parse_schema_tokens(Scanned, [H|Acc]).
 
--spec parse(list()) -> { mapping | translation | validator, tuple()} | errorlist().
+-spec parse(list()) -> { mapping | translation | validator, tuple()} | cuttlefish_error:errorlist().
 parse(Scanned) ->
     case erl_parse:parse_exprs(Scanned) of
         {ok, Parsed} ->

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -113,7 +113,7 @@ file(Filename) ->
     S = unicode:characters_to_list(B, utf8),
     case string(S) of
         {error, Errors} ->
-            cuttlefish_util:print_error("Error parsing schema: ~s", [Filename]),
+            cuttlefish_error:print("Error parsing schema: ~s", [Filename]),
             {error, Errors};
         Schema ->
             Schema
@@ -133,9 +133,9 @@ string(S) ->
                     [begin
                         case Desc of
                             [H|_] when is_list(H) ->
-                                [ cuttlefish_util:print_error(D) || D <- Desc];
+                                [cuttlefish_error:print(D) || D <- Desc];
                             _ ->
-                                cuttlefish_util:print_error(Desc)
+                                cuttlefish_error:print(Desc)
                         end
                     end || {error, Desc} <- Errors],
                     {error, Errors}

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -50,7 +50,7 @@ check_config_for_errors({error, Phase, {error, Errors}}) ->
     %% What if Config is an error? It'd be nice to know what that was
     cuttlefish_error:print("Error in phase: ~s", [Phase]),
     [ cuttlefish_error:print(E) || E <- Errors],
-    ?assert(fail);
+    ?assert(false);
 check_config_for_errors(_) ->
     ok.
 
@@ -58,9 +58,9 @@ assert_config(Config, Path, Value) ->
     check_config_for_errors(Config),
     ActualValue = case path(cuttlefish_variable:tokenize(Path), Config) of
         {error, bad_nesting} ->
-            ?assert(fail);
+            ?assert(false);
         notset ->
-            ?assert(fail);
+            ?assert(false);
         {ok, X} -> X
     end,
     ?assertEqual({Path, Value}, {Path, ActualValue}).
@@ -69,9 +69,9 @@ assert_not_configured(Config, Path) ->
     check_config_for_errors(Config),
     ActualValue = case path(cuttlefish_variable:tokenize(Path), Config) of
         {error, bad_nesting} ->
-            ?assert(fail);
+            ?assert(false);
         {ok, _} ->
-            ?assert(fail);
+            ?assert(false);
         notset -> undefined
     end,
     ?assertEqual({Path, undefined}, {Path, ActualValue}).

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -42,24 +42,29 @@
 ]).
 
 
-%% @depricated
+%% @deprecated
 conf_get_value(Key, Conf) ->
+    lager:warning("cuttlefish_util:conf_get_value/2 has been deprecated. use cuttlefish:conf_get/2"),
     cuttlefish:conf_get(Key, Conf).
 
-%% @depricated
+%% @deprecated
 conf_get_value(Key, Conf, Default) ->
+    lager:warning("cuttlefish_util:conf_get_value/3 has been deprecated. use cuttlefish:conf_get/3"),
     cuttlefish:conf_get(Key, Conf, Default).
 
-%% @depricated
+%% @deprecated
 filter_by_variable_starts_with(Prefix, Conf) ->
+    lager:warning("cuttlefish_util:filter_by_variable_starts_with/2 has been deprecated. use cuttlefish_variable:filter_by_prefix/2"),
     cuttlefish_variable:filter_by_prefix(Prefix, Conf).
 
-%% @depricated
+%% @deprecated
 matches_for_variable_def(VarDef, Conf) ->
+    lager:warning("cuttlefish_util:matches_for_variable_def/2 has been deprecated. use cuttlefish_variable:fuzzy_matches/2"),
     cuttlefish_variable:fuzzy_matches(VarDef, Conf).
 
-%% @depricated
+%% @deprecated
 fuzzy_variable_match(Var, VarDef) ->
+    lager:warning("cuttlefish_util:fuzzy_variable_match/2 has been deprecated. use cuttlefish_variable:is_fuzzy_match/2"),
     cuttlefish_variable:is_fuzzy_match(Var, VarDef).
 
 %% @doc replace the element in a proplist

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -32,6 +32,36 @@
     ceiling/1,
     levenshtein/2]).
 
+%% Legacy API
+-export([
+     conf_get_value/2,
+     conf_get_value/3,
+     filter_by_variable_starts_with/2,
+     matches_for_variable_def/2,
+     fuzzy_variable_match/2
+]).
+
+
+%% @depricated
+conf_get_value(Key, Conf) ->
+    cuttlefish:conf_get(Key, Conf).
+
+%% @depricated
+conf_get_value(Key, Conf, Default) ->
+    cuttlefish:conf_get(Key, Conf, Default).
+
+%% @depricated
+filter_by_variable_starts_with(Prefix, Conf) ->
+    cuttlefish_variable:filter_by_prefix(Prefix, Conf).
+
+%% @depricated
+matches_for_variable_def(VarDef, Conf) ->
+    cuttlefish_variable:fuzzy_matches(VarDef, Conf).
+
+%% @depricated
+fuzzy_variable_match(Var, VarDef) ->
+    cuttlefish_variable:is_fuzzy_match(Var, VarDef).
+
 %% @doc replace the element in a proplist
 -spec replace_proplist_value(atom() | string(), any(), [{string(), any()}]) -> [{string(), any()}].
 replace_proplist_value(Key, Value, Proplist) ->

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -27,11 +27,10 @@
 -endif.
 
 -export([
-    replace_proplist_value/3, numerify/1,
+    replace_proplist_value/3,
+    numerify/1,
     ceiling/1,
-    levenshtein/2,
-    print_error/1,
-    print_error/2]).
+    levenshtein/2]).
 
 %% @doc replace the element in a proplist
 -spec replace_proplist_value(atom() | string(), any(), [{string(), any()}]) -> [{string(), any()}].
@@ -63,16 +62,6 @@ ceiling(X) ->
         Neg when Neg < 0 -> T;
         Pos when Pos > 0 -> T + 1;
         _ -> T
-    end.
-
-print_error(FormatString, Args) ->
-    print_error(io_lib:format(FormatString, Args)).
-print_error(String) ->
-    case lager:error("~s", [String]) of
-        {error, lager_not_running} ->
-            io:format("~s~n", [String]),
-            ok;
-        ok -> ok
     end.
 
 %% Levenshtein code by Adam Lindberg, Fredrik Svensson via
@@ -149,7 +138,7 @@ levenshtein_test() ->
 print_error_test() ->
     case lager:error("Error") of
         {error, lager_not_running} ->
-            ?assertEqual(ok, print_error("Error"));
+            ?assertEqual(ok, (cuttlefish_error:print("Error")));
         _ ->
             ?assert(fail)
     end,

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -27,9 +27,7 @@
 -endif.
 
 -export([
-    replace_proplist_value/3,
-    filter_by_variable_starts_with/2,
-    numerify/1,
+    replace_proplist_value/3, numerify/1,
     ceiling/1,
     levenshtein/2,
     print_error/1,
@@ -39,14 +37,6 @@
 -spec replace_proplist_value(atom() | string(), any(), [{string(), any()}]) -> [{string(), any()}].
 replace_proplist_value(Key, Value, Proplist) ->
     lists:keystore(Key, 1, Proplist, {Key, Value}).
-
-%% @doc For Proplist, return the subset of the proplist that starts
-%% with "Key"
--spec filter_by_variable_starts_with(string()|[string()], [{[string()], any()}]) -> [{[string()], any()}].
-filter_by_variable_starts_with([H|_T]=Prefix, Proplist) when is_list(H) ->
-    [ T || {Key,_}=T <- Proplist, lists:prefix(Prefix, Key) ];
-filter_by_variable_starts_with(StringPrefix, Proplist) ->
-    filter_by_variable_starts_with(cuttlefish_variable:tokenize(StringPrefix), Proplist).
 
 %% @doc turn a string into a number in a way I am happy with
 -spec numerify(string()) -> integer()|float()|{error, string()}.
@@ -143,33 +133,6 @@ replace_proplist_value_when_undefined_test() ->
         3,
         proplists:get_value("test3", NewProplist)
         ),
-    ok.
-
-filter_by_variable_starts_with_test() ->
-    Proplist = [
-        {["regular","key"], 1},
-        {["other","normal","key"], 2},
-        {["prefixed","key1"], 3},
-        {["prefixed","key2"], 4},
-        {["interleaved","key"], 5},
-        {["prefixed","key3"], 6}
-    ],
-
-    FilteredByList = filter_by_variable_starts_with(["prefixed"], Proplist),
-    ?assertEqual([
-            {["prefixed","key1"], 3},
-            {["prefixed","key2"], 4},
-            {["prefixed","key3"], 6}
-        ],
-        FilteredByList),
-
-    FilteredByString = filter_by_variable_starts_with("prefixed", Proplist),
-    ?assertEqual([
-            {["prefixed","key1"], 3},
-            {["prefixed","key2"], 4},
-            {["prefixed","key3"], 6}
-        ],
-        FilteredByString),
     ok.
 
 levenshtein_test() ->

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -1,0 +1,70 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_variable: handles both variable and variable definitions
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_variable).
+
+-type variable() :: [string()].
+-export_type([variable/0]).
+
+-export([tokenize/1]).
+
+-export([split_variable_on_match/1]).
+
+%% @doc like string:tokens(Key, "."), but if the dot was escaped
+%% i.e. \\., don't tokenize that
+-spec tokenize(string()) ->  [string()].
+tokenize(Key) ->
+    tokenize(Key, "", []).
+
+tokenize([$\\, $. |Rest], Part, Acc) ->
+    tokenize(Rest, [$. |Part], Acc);
+tokenize([$. |Rest], Part, Acc) ->
+    tokenize(Rest, "", [lists:reverse(Part)|Acc]);
+tokenize([], "", Acc) ->
+    lists:reverse(Acc);
+tokenize([], Part, Acc) ->
+    lists:reverse([lists:reverse(Part)|Acc]);
+tokenize([Char|Rest], Part, Acc) ->
+    tokenize(Rest, [Char|Part], Acc).
+
+
+
+%% @doc split a key definition into:
+%% * Prefix: Things before the $var
+%% * Var: The $var itself
+%% * Suffix: Things after the $var
+-spec split_variable_on_match([string()]) -> {[string()], string(), [string()]}.
+split_variable_on_match(Variable) ->
+    {PrefixToks, MatchGroup, SuffixToks} = lists:foldl(
+        fun(T, {Prefix, MatchGroup, Suffix}) ->
+            case {T, MatchGroup} of
+                {[$$|_], []} -> {Prefix, T, Suffix};
+                {_, []} -> {[T|Prefix], MatchGroup, Suffix};
+                {_, _} -> {Prefix, MatchGroup, [T|Suffix]}
+            end
+        end,
+        {[], [], []},
+        Variable),
+    {
+        lists:reverse(PrefixToks),
+        MatchGroup,
+        lists:reverse(SuffixToks)
+    }.

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -7,14 +7,10 @@
 generated_conf_file_test() ->
     {_, Mappings, _} = cuttlefish_schema:file("../test/riak.schema"),
     cuttlefish_conf:generate_file(Mappings, "../generated.conf"),
-
     %% Schema generated a conf file, let's parse it!
     Conf = cuttlefish_conf:file("../generated.conf"),
-
     ?assertEqual("8099", proplists:get_value(["handoff","port"], Conf)),
-
     ok.
-
 
 %% This test generates a .config file from the riak.schema. view it at ../generated.config
 generated_config_file_test() ->

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -28,19 +28,19 @@ generated_config_file_test() ->
 breaks_on_fuzzy_and_strict_match_test() ->
     Schema = cuttlefish_schema:file("../test/riak.schema"),
     Conf = [{["listener", "protobuf", "$name"], "127.0.0.1:8087"}],
-    ?assertEqual({error, add_defaults}, cuttlefish_generator:map(Schema, Conf)),
+    ?assertMatch({error, add_defaults, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_bad_enum_test() ->
     Schema = cuttlefish_schema:file("../test/riak.schema"),
     Conf = [{["storage_backend"], penguin}],
-    ?assertEqual({error, transform_datatypes}, cuttlefish_generator:map(Schema, Conf)),
+    ?assertMatch({error, transform_datatypes, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 breaks_on_bad_validation_test() ->
     Schema = cuttlefish_schema:file("../test/riak.schema"),
     Conf = [{["ring_size"], 10}],
-    ?assertEqual({error, validation}, cuttlefish_generator:map(Schema, Conf)),
+    ?assertMatch({error, validation, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
 %% Tests that the schema can generate a default app.config from nothing
@@ -146,7 +146,7 @@ not_found_error_test() ->
     Schema = cuttlefish_schema:files(["../test/throw_not_found.schema"]),
     Conf = [],
     NewConfig = cuttlefish_generator:map(Schema, Conf),
-    ?assertEqual({error, apply_translations}, NewConfig).
+    ?assertMatch({error, apply_translations, _}, NewConfig).
 
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -23,8 +23,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_CRASH_DUMP", "dump"),
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", "256000"),
     cuttlefish_unit:assert_config(Config, "vm_args.+P", "256000"),
-    cuttlefish_unit:assert_config(Config, "vm_args.+zdbbl", undefined),
-    cuttlefish_unit:assert_config(Config, "vm_args.+sfwi", undefined),
+    cuttlefish_unit:assert_not_configured(Config, "vm_args.+zdbbl"),
+    cuttlefish_unit:assert_not_configured(Config, "vm_args.+sfwi"),
     ok.
 
 override_schema_test() ->

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -14,7 +14,7 @@
  "riak_kv.multi_backend",
  fun(Conf, Schema) ->
   %% group by $name into list, also cut the "multi_backend.$name" off every key
-  BackendNames = cuttlefish_util:matches_for_variable_def(["multi_backend","$name","storage_backend"], Conf),
+  BackendNames = cuttlefish_variable:fuzzy_matches(["multi_backend","$name","storage_backend"], Conf),
   %% for each in list, case statement on backend type
   [ begin
     BackendConfigName = ["multi_backend", Name],

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -23,7 +23,7 @@
         BackendConfigPrefix = BackendConfigName ++ ["bitcask"],
         SubConf = [ begin
           {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_util:filter_by_variable_starts_with(BackendConfigPrefix, Conf)],
+        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
 
         BackendProplist = cuttlefish_generator:map(Schema, SubConf),
 
@@ -32,7 +32,7 @@
         BackendConfigPrefix = BackendConfigName ++ ["leveldb"],
         SubConf = [ begin
           {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_util:filter_by_variable_starts_with(BackendConfigPrefix, Conf)],
+        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
 
         BackendProplist = cuttlefish_generator:map(Schema, SubConf),
 
@@ -41,7 +41,7 @@
         BackendConfigPrefix = BackendConfigName ++ ["memory_backend"],
         SubConf = [ begin
           {Key -- BackendConfigName, Value}
-        end || {Key, Value} <- cuttlefish_util:filter_by_variable_starts_with(BackendConfigPrefix, Conf)],
+        end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(BackendConfigPrefix, Conf)],
         BackendProplist = cuttlefish_generator:map(Schema, SubConf),
         {riak_kv_memory_backend, proplists:get_value(memory_backend, proplists:get_value(riak_kv, BackendProplist))};
       _ -> oops_all_berries

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -18,7 +18,7 @@
   %% for each in list, case statement on backend type
   [ begin
     BackendConfigName = ["multi_backend", Name],
-    {BackendModule, BackendConfig} = case cuttlefish_util:conf_get_value(BackendConfigName ++ ["storage_backend"], Conf) of
+    {BackendModule, BackendConfig} = case cuttlefish:conf_get(BackendConfigName ++ ["storage_backend"], Conf) of
       bitcask ->
         BackendConfigPrefix = BackendConfigName ++ ["bitcask"],
         SubConf = [ begin

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -135,7 +135,7 @@
 { translation,
   "riak_core.http",
     fun(Conf) ->
-        HTTP = cuttlefish_util:filter_by_variable_starts_with("listener.http", Conf),
+        HTTP = cuttlefish_variable:filter_by_prefix("listener.http", Conf),
         [ IP || {_, IP} <- HTTP]
     end
 }.
@@ -152,7 +152,7 @@
 { translation,
   "riak_api.pb",
     fun(Conf) ->
-        PB = cuttlefish_util:filter_by_variable_starts_with("listener.protobuf", Conf),
+        PB = cuttlefish_variable:filter_by_prefix("listener.protobuf", Conf),
         [ IP || {_, IP} <- PB]
     end
 }.
@@ -183,7 +183,7 @@
 { translation,
   "riak_core.https",
     fun(Conf) ->
-        HTTPS = cuttlefish_util:filter_by_variable_starts_with("listener.https", Conf),
+        HTTPS = cuttlefish_variable:filter_by_prefix("listener.https", Conf),
         [ IP || {_, IP} <- HTTPS]
     end
 }.

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -23,7 +23,7 @@
 { translation,
   "riak_kv.anti_entropy",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("anti_entropy", Conf),
+    Setting = cuttlefish:conf_get("anti_entropy", Conf),
     case Setting of
       on -> {on, []};
       debug -> {on, [debug]};
@@ -71,11 +71,11 @@
 { translation,
   "lager.handlers",
   fun(Conf) ->
-    SyslogHandler = case cuttlefish_util:conf_get_value("log.syslog", Conf) of
+    SyslogHandler = case cuttlefish:conf_get("log.syslog", Conf) of
       on ->  [{lager_syslog_backend, ["riak", daemon, info]}];
       _ -> []
     end,
-    ErrorHandler = case cuttlefish_util:conf_get_value("log.error.file", Conf) of
+    ErrorHandler = case cuttlefish:conf_get("log.error.file", Conf) of
       undefined -> [];
       ErrorFilename -> [{lager_file_backend, [{file, ErrorFilename},
                                               {level, error},
@@ -84,8 +84,8 @@
                                               {count, 5}]}]
     end,
 
-    ConsoleLogLevel = cuttlefish_util:conf_get_value("log.console.level", Conf),
-    ConsoleLogFile = cuttlefish_util:conf_get_value("log.console.file", Conf),
+    ConsoleLogLevel = cuttlefish:conf_get("log.console.level", Conf),
+    ConsoleLogFile = cuttlefish:conf_get("log.console.file", Conf),
 
     ConsoleHandler = {lager_console_handler, ConsoleLogLevel},
     ConsoleFileHandler = {lager_file_backend, [{file, ConsoleLogFile},
@@ -94,7 +94,7 @@
                                                 {date, "$D0"},
                                                 {count, 5}]},
 
-    ConsoleHandlers = case cuttlefish_util:conf_get_value("log.console", Conf) of
+    ConsoleHandlers = case cuttlefish:conf_get("log.console", Conf) of
       off -> [];
       file -> [ConsoleFileHandler];
       console -> [ConsoleHandler];
@@ -116,7 +116,7 @@
 { translation,
   "sasl.sasl_error_logger",
   fun(Conf) ->
-    case cuttlefish_util:conf_get_value("sasl", Conf) of %%how to pull default?
+    case cuttlefish:conf_get("sasl", Conf) of %%how to pull default?
         on -> true;
         _ -> false
     end
@@ -233,7 +233,7 @@
 { translation,
   "riak_core.dtrace_support",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("dtrace", Conf),
+    Setting = cuttlefish:conf_get("dtrace", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -272,7 +272,7 @@
 
 { translation,
   "riak_search.enabled", fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("search", Conf),
+    Setting = cuttlefish:conf_get("search", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -348,7 +348,7 @@ end}.
 
 { translation,
   "lager.error_logger_redirect", fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("log.error.redirect", Conf),
+    Setting = cuttlefish:conf_get("log.error.redirect", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -374,7 +374,7 @@ end}.
 { translation,
   "riak_kv.storage_backend",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("storage_backend", Conf),
+    Setting = cuttlefish:conf_get("storage_backend", Conf),
     case Setting of
       bitcask -> riak_kv_bitcask_backend;
       leveldb -> riak_kv_eleveldb_backend;
@@ -410,8 +410,8 @@ end}.
 {translation,
  "riak_kv.anti_entropy_build_limit",
  fun(Conf) ->
-    {cuttlefish_util:conf_get_value("anti_entropy.build_limit.number", Conf),
-     cuttlefish_util:conf_get_value("anti_entropy.build_limit.per_timespan", Conf)}
+    {cuttlefish:conf_get("anti_entropy.build_limit.number", Conf),
+     cuttlefish:conf_get("anti_entropy.build_limit.per_timespan", Conf)}
  end}.
 
 %% @doc Determine how often hash trees are expired after being built.
@@ -477,7 +477,7 @@ end}.
 { translation,
   "riak_kv.mapred_2i_pipe",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("mapred_2i_pipe", Conf),
+    Setting = cuttlefish:conf_get("mapred_2i_pipe", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -547,7 +547,7 @@ end}.
 { translation,
   "riak_kv.vnode_vclocks",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("vnode_vclocks", Conf),
+    Setting = cuttlefish:conf_get("vnode_vclocks", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -568,7 +568,7 @@ end}.
 { translation,
   "riak_kv.listkeys_backpressure",
   fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("listkeys_backpressure", Conf),
+    Setting = cuttlefish:conf_get("listkeys_backpressure", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -649,7 +649,7 @@ end}.
 {translation,
  "riak_control.enabled",
  fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("riak_control", Conf),
+    Setting = cuttlefish:conf_get("riak_control", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -667,7 +667,7 @@ end}.
 {translation,
 "riak_control.auth",
 fun(Conf) ->
-  case cuttlefish_util:conf_get_value("riak_control.auth", Conf) of
+  case cuttlefish:conf_get("riak_control.auth", Conf) of
     userlist -> userlist;
     off -> none;
     _ -> none
@@ -708,7 +708,7 @@ end}.
 {translation,
  "riak_control.admin",
  fun(Conf) ->
-    Setting = cuttlefish_util:conf_get_value("riak_control.admin", Conf),
+    Setting = cuttlefish:conf_get("riak_control.admin", Conf),
     case Setting of
       on -> true;
       off -> false;
@@ -772,12 +772,12 @@ end}.
 {translation,
  "bitcask.sync_strategy",
  fun(Conf) ->
-  Setting = cuttlefish_util:conf_get_value("bitcask.sync_strategy", Conf),
+  Setting = cuttlefish:conf_get("bitcask.sync_strategy", Conf),
     case Setting of
       none -> none;
       o_sync -> o_sync;
       interval ->
-        Interval = cuttlefish_util:conf_get_value("bitcask.sync_interval", Conf, undefined),
+        Interval = cuttlefish:conf_get("bitcask.sync_interval", Conf, undefined),
         {seconds, Interval};
       _Default -> none
     end
@@ -828,13 +828,13 @@ end}.
 {translation,
  "bitcask.merge_window",
  fun(Conf) ->
-  Setting = cuttlefish_util:conf_get_value("bitcask.merge_window", Conf),
+  Setting = cuttlefish:conf_get("bitcask.merge_window", Conf),
     case Setting of
       always -> always;
       never -> never;
       window ->
-        Start = cuttlefish_util:conf_get_value("bitcask.merge_window.start", Conf, undefined),
-        End = cuttlefish_util:conf_get_value("bitcask.merge_window.end", Conf, undefined),
+        Start = cuttlefish:conf_get("bitcask.merge_window.start", Conf, undefined),
+        End = cuttlefish:conf_get("bitcask.merge_window.end", Conf, undefined),
         {Start, End};
       _Default -> always
     end
@@ -1051,7 +1051,7 @@ end}.
 { translation,
   "eleveldb.use_bloomfilter",
   fun(Conf) ->
-    case cuttlefish_util:conf_get_value("leveldb.bloomfilter", Conf) of
+    case cuttlefish:conf_get("leveldb.bloomfilter", Conf) of
         on -> true;
         off -> false;
         _ -> true
@@ -1104,7 +1104,7 @@ end}.
 {translation,
  "riak_kv.memory_backend.max_memory",
  fun(Conf) ->
-  Bytes = cuttlefish_util:conf_get_value("memory_backend.max_memory", Conf),
+  Bytes = cuttlefish:conf_get("memory_backend.max_memory", Conf),
   cuttlefish_util:ceiling(Bytes / 1048576)
  end
 }.
@@ -1178,7 +1178,7 @@ end}.
 
 {translation, "vm_args.+P",
 fun(Conf) ->
-  Procs = cuttlefish_util:conf_get_value("process_limit", Conf),
+  Procs = cuttlefish:conf_get("process_limit", Conf),
   integer_to_list(Procs)
 end}.
 

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -687,7 +687,7 @@ end}.
 fun(Conf) ->
   UserList1 = lists:filter(
     fun({Var, _V}) ->
-      cuttlefish_util:fuzzy_variable_match(Var, ["riak_control","user","$username","password"])
+      cuttlefish_variable:is_fuzzy_match(Var, ["riak_control","user","$username","password"])
     end,
     Conf),
   UserList = [ begin

--- a/test/unset_translation.schema
+++ b/test/unset_translation.schema
@@ -3,7 +3,7 @@
 ]}.
 
 {translation, "erlang.key",
-    fun(Conf) -> cuttlefish_util:conf_get_value("a.b", Conf) * 17 end
+    fun(Conf) -> cuttlefish:conf_get("a.b", Conf) * 17 end
 }.
 
 %% nevermind, I don't want this translated.


### PR DESCRIPTION
I'd say the biggest thing in this PR is refactoring a lot of `variable` related code into a new `cuttlefish_variable` module and out of the `cuttlefish_util` module.

That broke some of the existing API for cuttlefish schema writers, so I left backwards compatible stubs in `cuttlefish_util`.

This also includes a new `cuttlefish_error` module, which is just a standard place to do error handley stuff.

The `cuttlefish` module is an entry API point. It's a better place than `cuttlefish_util` for exposed functions. I'll eventually put a wrapper for the things @jrwest is using for bucket type config in here so all users of cuttlefish need to worry about will be in this module. Speaking of @jrwest, there are some logging changes in this PR that should make his use case less verbose. `cuttlefish_generator:map/2` now returns a proplist or `{error, atom(), errorlist()}`.

Also in here, some more verbose debugging output that @Vagabond would have liked to have earlier this week.

Also, @uwiger found a previously untested case of prefix matching, and I've included his fix.
