### PR TITLE
Extended datatypes

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -88,7 +88,7 @@ generate_element(MappingRecord) ->
     Commented = cuttlefish_mapping:commented(MappingRecord),
     Level = cuttlefish_mapping:level(MappingRecord),
     IncDef = cuttlefish_mapping:include_default(MappingRecord),
-    Datatype = cuttlefish_mapping:datatype(MappingRecord),
+    [Datatype|_] = cuttlefish_mapping:datatype(MappingRecord),
     %% level != basic: leave out of generated .conf file
     %% commeneted $val: insert into .conf file, but commented out with $val
     %% include_default $val:  substitute '$name' or whatever in the key for $val

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -270,7 +270,7 @@
 %%
 %% Default is: `0`
 {mapping, "multi_backend.$name.bitcask.expiry_grace_time", "riak_kv.multi_backend", [
-  {datatype, {duration, secs}},
+  {datatype, {duration, s}},
   {level, advanced},
   {default, 0}
 ]}.


### PR DESCRIPTION
This one's for you @evanmcc and @jtuple 

Now, when writing a schema, you can add multiple datatypes. Here's how it works:

In a mapping, `{datatype, Type}` still works as it used to, but if you want, you can replace Type with a List of types.

Example: anti_entropy.expire

``` erlang
{mapping, "anti_entropy.expire", "riak_kv.anti_entropy.expire", [
    {datatype, [{duration, ms}, {atom, never}]}
]}.
```

now if you set something like `anti_entropy.expire = right_away` it will try converting "right_away" into a duration first. When that doesn't work, it'll try converting it to an atom and then compare to 'never'. Only if these all fail will it produce an error, and the first one to pass is the one it uses.

You can put any datatype that currently exists, and I've added a few more. These extended types are single instances of a type, like `{atom, never}`, which only allows the atom 'never'.

I hope that makes sense. Better documentation for this will come next week on the cuttlefish wiki. 
