### PR TITLE
Update neotoma to 1.7.0.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
     {lager, "2.0.*", {git, "git://github.com/basho/lager.git", {tag, "2.0.1"}}},
-    {neotoma, "1.6.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.6.2"}}}
+    {neotoma, "1.7.0", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.0"}}}
   ]}.
 
 {post_hooks, [{compile, "./rebar escriptize"}]}.


### PR DESCRIPTION
This removes the lingering dialyzer errors in `conf_parse` caused by unused combinators.
