### PR TITLE
Modify usage of throw in translations and add API wrappers.

### DIFF
--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -24,7 +24,9 @@
 
 -export([
     conf_get/2,
-    conf_get/3
+    conf_get/3,
+    unset/0,
+    invalid/1
 ]).
 
 % @doc conf_get/2 is a convenience wrapper for  proplists:get_value/2 for schema
@@ -44,7 +46,7 @@ conf_get([H|_T]=Variable, ConfigProplist) when is_list(H) ->
         true ->
             proplists:get_value(Variable, ConfigProplist);
         false ->
-            throw(not_found)
+            throw({not_found, Variable})
     end;
 conf_get(Variable, ConfigProplist) ->
     conf_get(
@@ -61,3 +63,15 @@ conf_get([H|_T]=Variable, ConfigProplist, Default) when is_list(H) ->
     proplists:get_value(Variable, ConfigProplist, Default);
 conf_get(Variable, ConfigProplist, Default) ->
     conf_get(cuttlefish_variable:tokenize(Variable), ConfigProplist, Default).
+
+%% @doc When called inside a translation, tells cuttlefish to omit the
+%% Erlang setting from the generated configuration.
+-spec unset() -> no_return().
+unset() ->
+    throw(unset).
+
+%% @doc When called inside a translation, informs the user that input
+%% configuration is invalid, using the supplied reason string.
+-spec invalid(string()) -> no_return().
+invalid(Reason) ->
+    throw({invalid, Reason}).


### PR DESCRIPTION
- Wrapped `throw(unset)` in API function `cuttlefish:unset/0`.
- Added the `throw({invalid, Reason})` protocol with wrapper function
  `cuttlefish:invalid/1`. This is used for translations that wish to
  convey that a configuration is invalid when discovered after the
  validation phase.
- Changed the `throw(not_found)` from `cuttlefish:conf_get/2` into a tuple
  of `{not_found, Variable}`. This allows translations to call `conf_get`
  for settings that are expected to be present and a useful message
  about which setting was requested can be included in the error.
