### PR TITLE
Give more helpful output during generate failure

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -68,7 +68,13 @@ file(Filename) ->
 generate(Mappings) ->
     lists:foldl(
       fun(Mapping, ConfFile) ->
-              ConfFile ++ generate_element(Mapping)
+              try
+                  Elem = generate_element(Mapping),
+                  ConfFile ++ Elem
+              catch _:Reason ->
+                      ST = erlang:get_stacktrace(),
+                      throw({Mapping,Reason,ST})
+              end
       end, [], Mappings).
 
 -spec generate_file([cuttlefish_mapping:mapping()], string()) -> ok.


### PR DESCRIPTION
I am trying to make a stagedevrel on riak-pre9 and keep getting this error.

```
ERROR: generate failed while processing /root/yz-src-verify/riak_yz/rel: {'EXIT',
    {badarg,
        [{io_lib,format,
            ["Default: ~s",
              [{error,"could not convert off of type flag to a string"}]],
            [{file,"io_lib.erl"},{line,155}]},
        {cuttlefish_conf,generate_comments,1,
            [{file,"src/cuttlefish_conf.erl"},{line,125}]},
...
```

It is kind of helpful but gives me no idea which file/mapping generated it. This patch adds more info.

```
ERROR: generate failed while processing /root/yz-src-verify/riak_yz/rel: {{mapping,["dtrace"],
          "riak_core.dtrace_support",off,undefined,
          [flag],
          basic,
          ["DTrace support Do not enable 'dtrace' unless your Erlang/OTP",
          "runtime is compiled to support DTrace.  DTrace is available in",
          "R15B01 (supported by the Erlang/OTP official source package) and in",
          "R14B04 via a custom source repository & branch."],
          undefined,[],false,[]},
badarg,
[{io_lib,format,
          ["Default: ~s",
          [{error,"could not convert off of type flag to a string"}]],
          [{file,"io_lib.erl"},{line,155}]},
...
```
