### PR TITLE
Added some missing logic for some cuttelfish_datatype:to_string edge cases

### DIFF
--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -156,10 +156,8 @@ to_string(Flag, {flag, _, _}=Type) when is_list(Flag) -> cuttlefish_flag:to_stri
 
 %% The Pokemon Clause: Gotta Catch 'em all!
 to_string(Value, MaybeExtendedDatatype) ->
-    io:format("is_extended(~p) = ~p~n", [MaybeExtendedDatatype, is_extended(MaybeExtendedDatatype)]),
     case is_extended(MaybeExtendedDatatype) of
         true ->
-            io:format("~p: ~p is extended from ~p~n", [Value, MaybeExtendedDatatype, extended_from(MaybeExtendedDatatype)]),
             to_string(Value, extended_from(MaybeExtendedDatatype));
         _ ->
             {error, lists:flatten(io_lib:format("Tried to convert ~p, an invalid datatype ~p to_string.", [Value, MaybeExtendedDatatype]))}

--- a/src/cuttlefish_flag.erl
+++ b/src/cuttlefish_flag.erl
@@ -85,15 +85,28 @@ parse_test() ->
 
 to_string_test() ->
     ?assertEqual(to_string(true, flag), "on"),
+    ?assertEqual(to_string(on, flag), "on"),
     ?assertEqual(to_string(false, flag), "off"),
+    ?assertEqual(to_string(off, flag), "off"),
     ?assertEqual(to_string(true, {flag, enabled, disabled}), "enabled"),
+    ?assertEqual(to_string(enabled, {flag, enabled, disabled}), "enabled"),
     ?assertEqual(to_string(false, {flag, enabled, disabled}), "disabled"),
+    ?assertEqual(to_string(disabled, {flag, enabled, disabled}), "disabled"),
     ?assertEqual(to_string(tyk, {flag, {on, tyk}, {off, torp}}), "on"),
+    ?assertEqual(to_string(on, {flag, {on, tyk}, {off, torp}}), "on"),
     ?assertEqual(to_string(torp, {flag, {on, tyk}, {off, torp}}), "off"),
+    ?assertEqual(to_string(off, {flag, {on, tyk}, {off, torp}}), "off"),
     ?assertEqual(to_string({long, tuple, value}, {flag, {simple, ok},
+                               {foo, {long, tuple, value}}}),
+                 "foo"),
+    ?assertEqual(to_string(foo, {flag, {simple, ok},
                                {foo, {long, tuple, value}}}),
                  "foo"),
     ?assertEqual(to_string(ok, {flag, {simple, ok},
                                {foo, {long, tuple, value}}}),
+                 "simple"),
+    ?assertEqual(to_string(simple, {flag, {simple, ok},
+                               {foo, {long, tuple, value}}}),
                  "simple").
+
 -endif.

--- a/src/cuttlefish_flag.erl
+++ b/src/cuttlefish_flag.erl
@@ -50,20 +50,22 @@ parse(Value, {flag, {On,OnValue}, {Off,OffValue}}) ->
                           " ~p", [Value, On, Off])}
     end.
 
-to_string(true, flag) ->
-    "on";
-to_string(false, flag) ->
-    "off";
-to_string(true, {flag, On, _}) when is_atom(On) ->
+to_string(Value, Flag) when is_list(Value) ->
+    to_string(list_to_atom(Value), Flag);
+to_string(Value, flag) ->
+    to_string(Value, {flag, {on, true}, {off, false}});
+to_string(On, {flag, {On, _}, _}) ->
     atom_to_list(On);
-to_string(false, {flag, _, Off}) when is_atom(Off) ->
-    atom_to_list(Off);
 to_string(OnValue, {flag, {On, OnValue}, _}) when is_atom(On) ->
     atom_to_list(On);
+to_string(Off, {flag, _, {Off, _}}) when is_atom(Off) ->
+    atom_to_list(Off);
 to_string(OffValue, {flag, _, {Off, OffValue}}) when is_atom(Off) ->
     atom_to_list(Off);
+to_string(Value, {flag, On, Off}) ->
+    to_string(Value, {flag, {On, true}, {Off, false}});
 to_string(Value, Flag) ->
-    {error, ?FMT("could not convert ~p of type ~p to a string", [Value, Flag])}.
+    {error, ?FMT("could not convert '~p' of type ~p to a string", [Value, Flag])}.
 
 
 -ifdef(TEST).


### PR DESCRIPTION
Fixes 

```
ERROR: generate failed while processing /home/buildbot/masters/riak/riak-build-centos-6-64/build/distdir/BUILD/riak-2.0.0pre9-6118bedf/rel: {'EXIT',
    {badarg,
        [{io_lib,format,
             ["Default: ~s",
              [{error,"could not convert off of type flag to a string"}]],
             [{file,"io_lib.erl"},{line,155}]},
         {cuttlefish_conf,generate_comments,1,
             [{file,"src/cuttlefish_conf.erl"},{line,125}]},
         {cuttlefish_conf,generate_element,1,
             [{file,"src/cuttlefish_conf.erl"},{line,108}]},
         {cuttlefish_conf,'-generate/1-fun-0-',2,
             [{file,"src/cuttlefish_conf.erl"},{line,71}]},
         {lists,foldl,3,[{file,"lists.erl"},{line,1248}]},
         {cuttlefish_conf,generate_file,2,
             [{file,"src/cuttlefish_conf.erl"},{line,76}]},
         {cuttlefish_rebar_plugin,make_default_file,3,
             [{file,"src/cuttlefish_rebar_plugin.erl"},{line,83}]},
         {cuttlefish_rebar_plugin,generate,2,
             [{file,"src/cuttlefish_rebar_plugin.erl"},{line,58}]}]}}
```

once that was fixed, this was exposed:

```
ERROR: generate failed while processing /Users/joe/dev/basho/riak_ee/rel: {'EXIT',
    {badarg,
        [{io_lib,format,
             ["Default: ~s",
              [{error,
                   "Tried to convert 1, an invalid datatype {integer,1} to_string."}]],
             [{file,"io_lib.erl"},{line,155}]},
         {cuttlefish_conf,generate_comments,1,
             [{file,"src/cuttlefish_conf.erl"},{line,126}]},
         {cuttlefish_conf,generate_element,1,
             [{file,"src/cuttlefish_conf.erl"},{line,108}]},
         {cuttlefish_conf,'-generate/1-fun-0-',2,
             [{file,"src/cuttlefish_conf.erl"},{line,71}]},
         {lists,foldl,3,[{file,"lists.erl"},{line,1248}]},
         {cuttlefish_conf,generate_file,2,
             [{file,"src/cuttlefish_conf.erl"},{line,76}]},
         {cuttlefish_rebar_plugin,make_default_file,3,
             [{file,"src/cuttlefish_rebar_plugin.erl"},{line,83}]},
         {cuttlefish_rebar_plugin,generate,2,
             [{file,"src/cuttlefish_rebar_plugin.erl"},{line,58}]}]}}
make: *** [generate] Error 1
```

Now both work.
