### PR TITLE
Refactor and fix cuttlefish_duration parsing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cuttlefish
 *.sublime-workspace
 log
 .local_dialyzer_plt
+src/cuttlefish_duration_parse.erl

--- a/src/cuttlefish_duration.erl
+++ b/src/cuttlefish_duration.erl
@@ -163,6 +163,9 @@ to_string_test() ->
 
 parse_error_test() ->
     ?assertMatch({error, _}, parse("1q")),
+    %% This previously raised badarith because it did not check the
+    %% return value of parse/1.
+    ?assertMatch({error, _}, catch parse("1q", h)),
     ok.
 
 -endif.

--- a/src/cuttlefish_duration.erl
+++ b/src/cuttlefish_duration.erl
@@ -24,12 +24,7 @@
 -opaque time_unit() :: f | w | d | h | m | s | ms.
 -export_type([time_unit/0]).
 
--define(FORTNIGHT, 1209600000).
--define(WEEK,      604800000).
--define(DAY,       86400000).
--define(HOUR,      3600000).
--define(MINUTE,    60000).
--define(SECOND,    1000).
+-include("cuttlefish_duration.hrl").
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
@@ -61,83 +56,29 @@ milliseconds(Millis) ->
     || {N, Unit} <- Units]).
 
 -spec parse(string(), time_unit()) -> integer().
-parse(DurationString, f) -> cuttlefish_util:ceiling(parse(DurationString) / ?FORTNIGHT);
-parse(DurationString, w) -> cuttlefish_util:ceiling(parse(DurationString) / ?WEEK);
-parse(DurationString, d) -> cuttlefish_util:ceiling(parse(DurationString) / ?DAY);
-parse(DurationString, h) -> cuttlefish_util:ceiling(parse(DurationString) / ?HOUR);
-parse(DurationString, m) -> cuttlefish_util:ceiling(parse(DurationString) / ?MINUTE);
-parse(DurationString, s) -> cuttlefish_util:ceiling(parse(DurationString) / ?SECOND);
-parse(DurationString, ms) -> parse(DurationString).
-
--spec parse(string()) -> integer().
-parse(InputDurationString) ->
-    DurationString = string:to_lower(InputDurationString),
-    DurationTokens = tokens(DurationString),
-
-    ParsedTokens = [parse_token(T) || T <- DurationTokens],
-
-    case lists:any(fun(X) -> X =:= error end, ParsedTokens) of
-        true ->
-            error;
-        false ->
-            Millis = lists:sum(ParsedTokens),
-            round(Millis)
+parse(DurationString, ms) -> parse(DurationString);
+parse(DurationString, Unit) ->
+    case parse(DurationString) of
+        {error, _}=Err ->
+            Err;
+        Num when is_number(Num) ->
+            {Unit, Multiplier} = lists:keyfind(Unit, 1, ?MULTIPLIERS),
+            cuttlefish_util:ceiling(Num / Multiplier)
     end.
 
-tokens(DurationString) ->
-    {LastWorking, List} = lists:foldl(
-        fun(Char, {Working, Acc}) ->
-            case {length(string:tokens(Working, "1234567890.")), is_digit(Char)} of
-                {0, _} ->
-                    {Working ++ [Char], Acc};
-                {_, true} ->
-                    {[Char], [Working|Acc]};
-                {_, false} ->
-                    {Working ++ [Char], Acc}
-            end
-        end,
-        {[], []},
-        DurationString),
-    [LastWorking|List].
 
-parse_token(T) -> parse_token_r(lists:reverse(T)).
+-spec parse(string()) -> integer() | cuttlefish_error:error().
+parse(InputDurationString) ->
+    DurationString = string:to_lower(InputDurationString),
+    case cuttlefish_duration_parse:parse(DurationString) of
+        Float when is_float(Float) ->
+            cuttlefish_util:ceiling(Float);
+        Int when is_integer(Int) ->
+            Int;
+        _ ->
+            {error, ?FMT("Invalid duration value: ~s", [InputDurationString])}
+    end.
 
-parse_token_r([$s,$m|BackwardMillis]) ->
-    MilliStr = lists:reverse(BackwardMillis),
-    cuttlefish_util:numerify(MilliStr);
-parse_token_r([$s|BackwardsSeconds]) ->
-    SecondStr = lists:reverse(BackwardsSeconds),
-    ?SECOND * cuttlefish_util:numerify(SecondStr);
-parse_token_r([$m|BackwardsMinutes]) ->
-    MinuteStr = lists:reverse(BackwardsMinutes),
-    ?MINUTE * cuttlefish_util:numerify(MinuteStr);
-parse_token_r([$h|BackwardsHours]) ->
-    HourStr = lists:reverse(BackwardsHours),
-    ?HOUR * cuttlefish_util:numerify(HourStr);
-parse_token_r([$d|BackwardsDays]) ->
-    DayStr = lists:reverse(BackwardsDays),
-    cuttlefish_util:numerify(DayStr) * ?DAY;
-parse_token_r([$w|BackwardsWeeks]) ->
-    WeekStr = lists:reverse(BackwardsWeeks),
-    cuttlefish_util:numerify(WeekStr) * ?WEEK;
-parse_token_r([$f|BackwardsFortnights]) ->
-    FortnightStr = lists:reverse(BackwardsFortnights),
-    cuttlefish_util:numerify(FortnightStr) * ?FORTNIGHT;
-parse_token_r(_UnknownUnit) ->
-    error.
-
-is_digit(Char) ->
-    Char =:= $1 orelse
-    Char =:= $2 orelse
-    Char =:= $3 orelse
-    Char =:= $4 orelse
-    Char =:= $5 orelse
-    Char =:= $6 orelse
-    Char =:= $7 orelse
-    Char =:= $8 orelse
-    Char =:= $9 orelse
-    Char =:= $0 orelse
-    Char =:= $..
 -ifdef(TEST).
 
 milliseconds_test() ->
@@ -221,7 +162,7 @@ to_string_test() ->
     ok.
 
 parse_error_test() ->
-    ?assertEqual(error, parse("1q")),
+    ?assertMatch({error, _}, parse("1q")),
     ok.
 
 -endif.

--- a/src/cuttlefish_duration.hrl
+++ b/src/cuttlefish_duration.hrl
@@ -1,0 +1,16 @@
+-define(FMT(F,A), lists:flatten(io_lib:format(F,A))).
+-define(FORTNIGHT, 1209600000).
+-define(WEEK,      604800000).
+-define(DAY,       86400000).
+-define(HOUR,      3600000).
+-define(MINUTE,    60000).
+-define(SECOND,    1000).
+
+-define(MULTIPLIERS,
+        [{f, ?FORTNIGHT},
+         {w, ?WEEK},
+         {d, ?DAY},
+         {h, ?HOUR},
+         {m, ?MINUTE},
+         {s, ?SECOND},
+         {ms, 1}]).

--- a/src/cuttlefish_duration_parse.peg
+++ b/src/cuttlefish_duration_parse.peg
@@ -1,0 +1,51 @@
+%% Duration string parser
+
+duration <- duration_segment+ `lists:sum(Node)`;
+
+duration_segment <- (float / integer) unit `
+    [Amount, Span] = Node,
+    {Span, Multiplier} = lists:keyfind(Span, 1, ?MULTIPLIERS),
+    Amount * Multiplier
+`;
+
+integer <- [1-9] [0-9]* `list_to_integer(?FLATTEN(Node))`;
+
+unit <- "f" / "w" / "d" / "h" / "ms" / "m" / "s"  `binary_to_atom(Node, latin1)`;
+
+float <- ( [0-9]+ "." [0-9]+ ) / ( "." [0-9]+ ) `
+   case Node of 
+       [<<".">>, Mantissa] ->
+           list_to_float(?FLATTEN(["0.", Mantissa]));
+       _ ->
+           list_to_float(?FLATTEN(Node))
+   end
+`;
+
+`
+
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_duration_parse: parses duration strings
+%%
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-include("cuttlefish_duration.hrl").
+
+-define(FLATTEN(S), binary_to_list(iolist_to_binary(S))).
+`

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -892,6 +892,7 @@ extended_datatypes_test() ->
     assert_extended_datatype([integer, {atom, never}], "1", 1),
     assert_extended_datatype([integer, {atom, never}], "never", never),
     assert_extended_datatype([integer, {atom, never}], "always", {error, transform_datatypes, "Error transforming datatype for: a.b"}),
+    assert_extended_datatype([{duration, s}, {atom, never}], "never", never),
     %%("Bad datatype: ~s ~s", [string:join(Variable, "."), Message]
     ok.
 

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -144,6 +144,13 @@ not_found_error_test() ->
     NewConfig = cuttlefish_generator:map(Schema, Conf),
     ?assertMatch({error, apply_translations, _}, NewConfig).
 
+extended_type_test() ->
+    lager:start(),
+    Schema = cuttlefish_schema:files(["../test/extended_types.schema"]),
+    Conf = conf_parse:parse(<<"a.b.c = foo\n">>),
+    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    ?assertEqual(foo, proplists:get_value(extended, proplists:get_value(cuttlefish, NewConfig))).
+
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),
     ActualKeys = lists:sort(proplists:get_keys(Actual)),

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -144,12 +144,21 @@ not_found_error_test() ->
     NewConfig = cuttlefish_generator:map(Schema, Conf),
     ?assertMatch({error, apply_translations, _}, NewConfig).
 
-extended_type_test() ->
+duration_test() ->
     lager:start(),
-    Schema = cuttlefish_schema:files(["../test/extended_types.schema"]),
+    Schema = cuttlefish_schema:files(["../test/durations.schema"]),
+    
+    %% Test that the duration parsing doesn't emit "error" into the
+    %% config instead of the extended type.
     Conf = conf_parse:parse(<<"a.b.c = foo\n">>),
     NewConfig = cuttlefish_generator:map(Schema, Conf),
-    ?assertEqual(foo, proplists:get_value(extended, proplists:get_value(cuttlefish, NewConfig))).
+    ?assertEqual(foo, proplists:get_value(duration_extended, proplists:get_value(cuttlefish, NewConfig))),
+
+    %% Test that for a non-extended duration, a bad value results in
+    %% an erroroneous config, not emitting error.
+    Conf2 = conf_parse:parse(<<"b.c = fish\n">>),
+    ErrConfig = cuttlefish_generator:map(Schema, Conf2),
+    ?assertMatch({error, transform_datatypes, _}, ErrConfig).
 
 proplist_equals(Expected, Actual) ->
     ExpectedKeys = lists:sort(proplists:get_keys(Expected)),

--- a/test/durations.schema
+++ b/test/durations.schema
@@ -1,0 +1,9 @@
+{mapping, "a.b.c", "cuttlefish.duration_extended", [
+  {default, "1m"},
+  {datatype, [{duration, s}, {atom, foo}]}
+]}.
+
+{mapping, "b.c", "cuttlefish.duration", [
+  {default, "10s"},
+  {datatype, {duration, ms}}
+]}.

--- a/test/extended_types.schema
+++ b/test/extended_types.schema
@@ -1,4 +1,0 @@
-{mapping, "a.b.c", "cuttlefish.extended", [
-  {default, "1m"},
-  {datatype, [{duration, s}, {atom, foo}]}
-]}.

--- a/test/extended_types.schema
+++ b/test/extended_types.schema
@@ -1,0 +1,4 @@
+{mapping, "a.b.c", "cuttlefish.extended", [
+  {default, "1m"},
+  {datatype, [{duration, s}, {atom, foo}]}
+]}.


### PR DESCRIPTION
The main fix here is that `cuttlefish_duration:parse/1,2` will now
properly return `{error, Reason}` instead of just `error` when an
invalid duration is parsed. Previously, this caused `error` to be
emitted in the generated config files as seen in basho/riak_kv#809.

Also, in some cases `badarith` exceptions might be raised when calling
`parse/2` because it assumed the parse result was correct and not an
error.

This adds another neotoma parser to the project because the original
code was too difficult to understand and verify, IMO. The new parser
returns a number when it successfully consumes the entire input, any
other result (incomplete parse, parse failure) is treated as an
erroneous duration value.

There are two tests that verify the fix for basho/riak_kv#809, one
uses a schema fixture in `cuttlefish_integration_test`, the other adds
another case to the extended types test in `cuttlefish_generator`.
