### PR TITLE
Remove +Q and +e flags from being generated if using R15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cuttlefish
 log
 .local_dialyzer_plt
 src/cuttlefish_duration_parse.erl
+erln8.config

--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -238,3 +238,24 @@
   {datatype, integer},
   {level, advanced}
 ]}.
+
+%% The +Q and +e flags are not supported in Erlang R15. Do not let erlang docs
+%% fool you into believing +e being supported, beam will fail if you attempt to pass it.
+%% These translations remove those flags if you use R15
+{translation, "vm_args.+Q",
+ fun(Conf) ->
+    case erlang:system_info(otp_release) of
+        [$R,$1,N|_] when N >= $6->
+             cuttlefish:conf_get("erlang.max_ports", Conf);
+                _ ->            cuttlefish:unset()
+    end
+end}.
+
+{translation, "vm_args.+e",
+ fun(Conf) ->
+    case erlang:system_info(otp_release) of
+        [$R,$1,N|_] when N >= $6->
+             cuttlefish:conf_get("erlang.max_ets_tables", Conf);
+                _ ->            cuttlefish:unset()
+    end
+end}.

--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -120,9 +120,11 @@
 {validator, "range:0-1024", "must be 0 to 1024",
  fun(X) -> X >= 0 andalso X =< 1024 end}.
 
+%% Note: OTP R15 and earlier uses -env ERL_MAX_PORTS, R16+ uses +Q
 %% @doc The number of concurrent ports/sockets
 %% Valid range is 1024-134217727
-{mapping, "erlang.max_ports", "vm_args.+Q", [
+{mapping, "erlang.max_ports",
+  cuttlefish:otp("R16", "vm_args.+Q", "vm_args.-env ERL_MAX_PORTS"), [
   {default, 65536},
   {datatype, integer},
   {validators, ["range4ports"]}
@@ -156,8 +158,11 @@
   {level, advanced}
 ]}.
 
+%% Note: OTP R15 and earlier uses -env ERL_MAX_ETS_TABLES,
+%% R16+ uses +e
 %% @doc Raise the ETS table limit
-{mapping, "erlang.max_ets_tables", "vm_args.+e", [
+{mapping, "erlang.max_ets_tables",
+  cuttlefish:otp("R16", "vm_args.+e", "vm_args.-env ERL_MAX_ETS_TABLES"), [
   {default, 256000},
   {datatype, integer},
   {level, advanced}
@@ -238,24 +243,3 @@
   {datatype, integer},
   {level, advanced}
 ]}.
-
-%% The +Q and +e flags are not supported in Erlang R15. Do not let erlang docs
-%% fool you into believing +e being supported, beam will fail if you attempt to pass it.
-%% These translations remove those flags if you use R15
-{translation, "vm_args.+Q",
- fun(Conf) ->
-    case erlang:system_info(otp_release) of
-        [$R,$1,N|_] when N >= $6->
-             cuttlefish:conf_get("erlang.max_ports", Conf);
-                _ ->            cuttlefish:unset()
-    end
-end}.
-
-{translation, "vm_args.+e",
- fun(Conf) ->
-    case erlang:system_info(otp_release) of
-        [$R,$1,N|_] when N >= $6->
-             cuttlefish:conf_get("erlang.max_ets_tables", Conf);
-                _ ->            cuttlefish:unset()
-    end
-end}.

--- a/rebar.config
+++ b/rebar.config
@@ -11,7 +11,7 @@
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
     {lager, "2.0.*", {git, "git://github.com/basho/lager.git", {tag, "2.0.2"}}},
-    {neotoma, "1.7.0", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.0"}}}
+    {neotoma, "1.7.1", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.1"}}}
   ]}.
 
 {post_hooks, [{compile, "./rebar escriptize"}]}.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -135,7 +135,7 @@ otp_test() ->
     ?assert(otp("R16", "R16B03")),
     ?assert(otp("R16", "R16A")),
     ?assert(not(otp("R16A", "R16"))),
-
+    ?assert(not(otp("R16", "R16"))),
     ok.
 
 -endif.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -126,10 +126,16 @@ invalid(Reason) ->
 -ifdef(TEST).
 
 otp_test() ->
+    ?assert(otp("R15B02", "R15B02-basho3")),
+    ?assert(not(otp("R15B02-basho3", "R15B02"))),
+    ?assert(otp("R16B02-basho3", "R16B03")),
     ?assert(otp("R15B01", "R15B02")),
     ?assert(otp("R15B01", "R15B02-basho3")),
     ?assert(not(otp("R16B01", "R15B02"))),
     ?assert(otp("R16", "R16B03")),
+    ?assert(otp("R16", "R16A")),
+    ?assert(not(otp("R16A", "R16"))),
+
     ok.
 
 -endif.

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -18,15 +18,21 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.-name", "node@host"),
     cuttlefish_unit:assert_config(Config, "vm_args.-setcookie", "erlang"),
     cuttlefish_unit:assert_config(Config, "vm_args.+A", 64),
-    cuttlefish_unit:assert_config(Config, "vm_args.+Q", 65536),
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_FULLSWEEP_AFTER", 0),
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_CRASH_DUMP", "dump"),
-    cuttlefish_unit:assert_config(Config, "vm_args.+e", 256000),
     cuttlefish_unit:assert_config(Config, "vm_args.+P", 256000),
     cuttlefish_unit:assert_not_configured(Config, "vm_args.+zdbbl"),
     cuttlefish_unit:assert_not_configured(Config, "vm_args.+sfwi"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_min"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_max"),
+    case erlang:system_info(otp_release) of
+        [$R, $1, N|_] when N >= $6 ->
+            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 65536),
+            cuttlefish_unit:assert_config(Config, "vm_args.+e", 256000);
+        _ ->
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_PORTS", 65536),
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 256000)
+    end,
     ok.
 
 override_schema_test() ->
@@ -62,15 +68,25 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.-name", "mynode@myhost"),
     cuttlefish_unit:assert_config(Config, "vm_args.-setcookie", "riak"),
     cuttlefish_unit:assert_config(Config, "vm_args.+A", 22),
-    cuttlefish_unit:assert_config(Config, "vm_args.+Q", 32000),
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_FULLSWEEP_AFTER", 1),
     cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_CRASH_DUMP", "place"),
-    cuttlefish_unit:assert_config(Config, "vm_args.+e", 128000),
     cuttlefish_unit:assert_config(Config, "vm_args.+P", 128001),
     cuttlefish_unit:assert_config(Config, "vm_args.+zdbbl", 1),
     cuttlefish_unit:assert_config(Config, "vm_args.+sfwi", 500),
     cuttlefish_unit:assert_config(Config, "kernel.inet_dist_listen_min", 6000),
     cuttlefish_unit:assert_config(Config, "kernel.inet_dist_listen_max", 7999),
+
+    %% These settings are version dependent, so we won't even test them here
+    %% because we don't know what version you're running, so we'll cover it
+    %% in two tests below
+    case erlang:system_info(otp_release) of
+        [$R, $1, N|_] when N >= $6 ->
+            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 32000),
+            cuttlefish_unit:assert_config(Config, "vm_args.+e", 128000);
+        _ ->
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_PORTS", 32000),
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 128000)
+    end,
     ok.
 
 erlang_scheduler_test() ->


### PR DESCRIPTION
Erlang R15 does not support the +Q or +e flags.  This change
simple applies a translation to remove those flags if
R15 is being used.
