### PR TITLE
Right Hand Side Substitutions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
+DIALYZER_APPS = kernel stdlib sasl erts ssl tools os_mon runtime_tools crypto inets \
 	public_key mnesia syntax_tools compiler
 COMBO_PLT = $(HOME)/.cuttlefish_combo_dialyzer_plt
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -462,7 +462,8 @@ value_sub(Var, Value, Conf, History) when is_list(Value) ->
                                           [string:join(Var, "."), StrToSub])};
                          {NewValToSub, AlmostNewConf} ->
                              NewValue = string:substr(Value, 1, L-1) ++ NewValToSub ++ string:substr(Value, R+?RSUBLEN),
-                             {NewValue, [{Var, NewValue}|proplists:delete(Var, AlmostNewConf)]}
+                             {PossiblyEvenMoreSubbedValue, EvenMoreAlmostNewConf} = value_sub(Var, NewValue, AlmostNewConf, []),
+                             {PossiblyEvenMoreSubbedValue, [{Var, PossiblyEvenMoreSubbedValue}|proplists:delete(Var, EvenMoreAlmostNewConf)]}
                      end;
                  _ ->
                      {Value, Conf}
@@ -1043,4 +1044,13 @@ value_sub_whitespace_test() ->
     ?assertEqual("/tyktorp/svagen", proplists:get_value(["d"], NewConf)),
     ok.
 
+value_sub_multiple_sub_test() ->
+    Conf = [
+            {["a"], "/a"},
+            {["b"], "/b"},
+            {["c"], "#(a)#(b)"}
+           ],
+    {NewConf, []} = value_sub(Conf),
+    ?assertEqual("/a/b", proplists:get_value(["c"], NewConf)),
+    ok.
 -endif.

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -63,7 +63,7 @@ map_value_sub(Schema, Config) ->
      case value_sub(Config) of
          {SubbedConfig, []} ->
             map_transform_datatypes(Schema, SubbedConfig);
-         {[], EList} ->
+         {_, EList} ->
             {error, rhs_subs, {error, EList}}
     end.
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -437,7 +437,7 @@ value_sub(Var, Value, Conf) ->
                 string(),
                 cuttlefish_conf:conf(),
                 [string()]) ->
-      {string(), cuttlefish_conf:conf()} | cuttlefish_error:error().
+      {string() | undefined, cuttlefish_conf:conf()} | cuttlefish_error:error().
 value_sub(Var, Value, Conf, History) when is_list(Value) ->
      %% Check if history contains duplicates. if so error
      case erlang:length(History) == sets:size(sets:from_list(History)) of
@@ -450,8 +450,8 @@ value_sub(Var, Value, Conf, History) when is_list(Value) ->
                  true -> %% RHS Alert
                      %% 1. get the var to find
                      StrToSub = string:strip(string:substr(Value, L+?LSUBLEN, R-L-?LSUBLEN)),
-                     %% 2. pull var from Conf
                      VarToSub = cuttlefish_variable:tokenize(StrToSub),
+                     %% 2. pull var from Conf
                      ValueSub = proplists:get_value(VarToSub, Conf),
                      %% 3. does that var need a sub too?
                      case value_sub(VarToSub, ValueSub, Conf, [Var|History]) of

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -439,11 +439,9 @@ value_sub(Var, Value, Conf) ->
                 [string()]) ->
       {string() | undefined, cuttlefish_conf:conf()} | cuttlefish_error:error().
 value_sub(Var, Value, Conf, History) when is_list(Value) ->
-     io:format("value_sub(~p, ~p, Conf, ~p)~n", [Var, Value, History]),
      %% Check if history contains duplicates. if so error
      case erlang:length(History) == sets:size(sets:from_list(History)) of
          false ->
-             io:format("Error: ~p~n", [History]),
              {error, ?FMT("Circular RHS substitutions: ~p", [History])};
          _ ->
              case head_sub(Value) of
@@ -454,7 +452,7 @@ value_sub(Var, Value, Conf, History) when is_list(Value) ->
                          {error, _EMsg} = Error ->
                              Error;
                          {undefined, _} ->
-                             {error, ?FMT("'~s' requires config variable '~s' is set",
+                             {error, ?FMT("'~s' substitution requires a config variable '~s' to be set",
                                           [string:join(Var, "."), string:join(NextVar, ".")])};
                          {NewValToSub, AlmostNewConf} ->
                              NewValue = SubFront ++ NewValToSub ++ SubBack,
@@ -1032,7 +1030,7 @@ value_sub_not_found_test() ->
            ],
     {_NewConf, Errors} = value_sub(Conf),
     ?assertEqual([
-                   {error, "'a' requires config variable 'b' is set"}
+                   {error, "'a' substitution requires a config variable 'b' to be set"}
                  ], Errors),
     ok.
 

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -1072,4 +1072,14 @@ value_sub_error_in_second_sub_test() ->
                  ], Errors),
     ok.
 
+value_sub_false_circle_test() ->
+    Conf = [
+            {["a"], "#(c)/#(c)"},
+            {["c"], "C"}
+           ],
+    {NewConf, Errors} = value_sub(Conf),
+    ?assertEqual([], Errors),
+    ?assertEqual("C/C", proplists:get_value(["a"], NewConf)),
+    ok.
+
 -endif.

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -27,6 +27,21 @@ breaks_on_fuzzy_and_strict_match_test() ->
     ?assertMatch({error, add_defaults, _}, cuttlefish_generator:map(Schema, Conf)),
     ok.
 
+breaks_on_rhs_not_found_test() ->
+    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Conf = [{["ring", "state_dir"], "#(tyktorp)/ring"}],
+    ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
+    ok.
+
+breaks_on_rhs_infinite_loop_test() ->
+    Schema = cuttlefish_schema:file("../test/riak.schema"),
+    Conf = [
+            {["ring", "state_dir"], "#(platform_data_dir)/ring"},
+            {["platform_data_dir"], "#(ring.state_dir)/data"}
+           ],
+    ?assertMatch({error, rhs_subs, _}, cuttlefish_generator:map(Schema, Conf)),
+    ok.
+
 breaks_on_bad_enum_test() ->
     Schema = cuttlefish_schema:file("../test/riak.schema"),
     Conf = [{["storage_backend"], penguin}],
@@ -147,7 +162,7 @@ not_found_error_test() ->
 duration_test() ->
     lager:start(),
     Schema = cuttlefish_schema:files(["../test/durations.schema"]),
-    
+
     %% Test that the duration parsing doesn't emit "error" into the
     %% config instead of the extended type.
     Conf = conf_parse:parse(<<"a.b.c = foo\n">>),

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -169,7 +169,7 @@
 
 %% @doc Default location of ringstate
 {mapping, "ring.state_dir", "riak_core.ring_state_dir", [
-  {default, "./data/ring"}
+  {default, "#(platform_data_dir)/ring"}
 ]}.
 
 %% @doc listener.https.<name> is an IP address and TCP port that the Riak


### PR DESCRIPTION
This is the ability to have settings depend on other settings, either explicitly or by default.

Imagine a `riak.conf` file:

```
##
## Default: ./data
##
## Acceptable values:
##   - the path to a directory
platform_data_dir = ./lore

## Default location of ringstate
##
## Default: #(platform_data_dir)/ring
##
## Acceptable values:
##   - the path to a directory
ring.state_dir = #(platform_data_dir)/ring
```

If you change `platform_data_dir`, `ring.state_dir` will also change

The effective config will still display the relative value:

```
...
platform_data_dir = ./lore
ring.state_dir = #(platform_data_dir)/ring
...
```

But the generated `app.config` will have a hard substitution

```
[
  {riak_core, [
    {platform_data_dir, "./lore"},
    {ring_state_dir, "./lore/ring"}
  ]}
].
```

This will allow for a more consistent experience when sub directories in riak.

Here are some caveats:
- If you're including a RHS sub as a default, that default must be a string

I'll open up a PR against riak_core so you can see how this would work in practice.
