### PR TITLE
EQC for cuttlefish_datatypes:to_string/2

### DIFF
--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -182,7 +182,7 @@ from_string(String, integer) when is_list(String) ->
         _:_ -> {error, lists:flatten(io_lib:format("~p can't be converted to an integer", [String]))}
     end;
 
-from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
+from_string({IP, Port}, ip) when is_list(IP), is_integer(Port), Port >= 0 -> {IP, Port};
 from_string(String, ip) ->
     try begin
         Parts = string:tokens(String, ":"),
@@ -194,10 +194,10 @@ from_string(String, ip) ->
         _:_ -> {error, lists:flatten(io_lib:format("~p cannot be converted into an IP", [String]))}
     end;
 
-from_string(Duration, {duration, _}) when is_integer(Duration) -> Duration;
+from_string(Duration, {duration, _}) when is_integer(Duration), Duration >= 0 -> Duration;
 from_string(Duration, {duration, Unit}) when is_list(Duration) -> cuttlefish_duration:parse(Duration, Unit);
 
-from_string(Bytesize, bytesize) when is_integer(Bytesize) -> Bytesize;
+from_string(Bytesize, bytesize) when is_integer(Bytesize), Bytesize >= 0 -> Bytesize;
 from_string(Bytesize, bytesize) when is_list(Bytesize) -> cuttlefish_bytesize:parse(Bytesize);
 
 from_string(String, string) when is_list(String) -> String;

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -131,17 +131,17 @@ to_string(Atom, atom) when is_atom(Atom) -> atom_to_list(Atom);
 to_string(Integer, integer) when is_integer(Integer) -> integer_to_list(Integer);
 to_string(Integer, integer) when is_list(Integer) -> Integer;
 
-to_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> IP ++ ":" ++ integer_to_list(Port);
+to_string({IP, Port}, ip) when is_list(IP), is_integer(Port), Port >= 0 -> IP ++ ":" ++ integer_to_list(Port);
 to_string(IPString, ip) when is_list(IPString) -> IPString;
 
 to_string(Enum, {enum, _}) when is_list(Enum) -> Enum;
 to_string(Enum, {enum, _}) when is_atom(Enum) -> atom_to_list(Enum);
 
 to_string(Duration, {duration, _}) when is_list(Duration) -> Duration;
-to_string(Duration, {duration, Unit}) when is_integer(Duration) -> cuttlefish_duration:to_string(Duration, Unit);
+to_string(Duration, {duration, Unit}) when is_integer(Duration), Duration >= 0 -> cuttlefish_duration:to_string(Duration, Unit);
 
 to_string(Bytesize, bytesize) when is_list(Bytesize) -> Bytesize;
-to_string(Bytesize, bytesize) when is_integer(Bytesize) -> cuttlefish_bytesize:to_string(Bytesize);
+to_string(Bytesize, bytesize) when is_integer(Bytesize), Bytesize >= 0 -> cuttlefish_bytesize:to_string(Bytesize);
 
 to_string(String, string) when is_list(String) -> String;
 

--- a/test/cuttlefish_datatypes_eqc.erl
+++ b/test/cuttlefish_datatypes_eqc.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% cuttlefish_eqc: EQC tests for cuttlefish
+%% cuttlefish_datatypes_eqc: EQC tests for cuttlefish
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
 %%
@@ -19,7 +19,7 @@
 %% under the License.
 %%
 %% -------------------------------------------------------------------
--module(cuttlefish_eqc).
+-module(cuttlefish_datatypes_eqc).
 -compile(export_all).
 
 -ifdef(EQC).

--- a/test/cuttlefish_eqc.erl
+++ b/test/cuttlefish_eqc.erl
@@ -1,0 +1,146 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_eqc: EQC tests for cuttlefish
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_eqc).
+-compile(export_all).
+
+-ifdef(EQC).
+
+-define(NUM_TESTS, 1000).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+
+eqc_test_() ->
+    [?_assert(prop_helper() =:= true)].
+
+prop_helper() ->
+    prop_helper(?NUM_TESTS).
+
+prop_helper(NumTests) ->
+    eqc:quickcheck(eqc:numtests(NumTests, prop_valid_to_string())).
+
+
+%% generators
+gen_non_blank_string() ->
+    not_empty(list(gen_lower_char())).
+
+gen_maybe_blank_string() ->
+    ?LET(X, list(gen_lower_char()), X).
+
+%% Generate a lower 7-bit ACSII character that should not cause any problems
+%% with utf8 conversion.
+gen_lower_char() ->
+    choose(16#20, 16#7f).
+
+not_empty(G) ->
+    ?SUCHTHAT(X, G, X /= [] andalso X /= <<>>).
+
+gen_atom() ->
+ ?LET(S, gen_maybe_blank_string(), list_to_atom(S)).
+
+gen_atom_datatype() ->
+    ?LET(X, oneof([gen_atom(), gen_maybe_blank_string()]), {atom, X}).
+
+gen_int_as_list() ->
+    ?LET(X, largeint(), integer_to_list(X)).
+
+gen_integer_datatype() ->
+    ?LET(X, oneof([int(), largeint(), gen_int_as_list()]), {integer, X}).
+
+gen_ip_pair() ->
+    ?LET(IP, gen_maybe_blank_string(),
+         ?LET(Port, int(), {IP, Port})).
+
+gen_ip_datatype() ->
+    ?LET(X, oneof([gen_ip_pair(), gen_non_blank_string()]), {ip, X}).
+
+gen_enum_datatype() ->
+    ?LET(X, oneof([gen_atom(), gen_maybe_blank_string()]), {{enum,foo}, X}).
+
+gen_bytesize_datatype() ->
+    ?LET(X, oneof([gen_int_as_list(), int(), largeint()]), {bytesize, X}).
+
+gen_string_datatype() ->
+    ?LET(X, gen_maybe_blank_string(), {string, X}).
+
+gen_filename_datatype() ->
+    ?LET(X, gen_maybe_blank_string(), {file, X}).
+
+gen_dirname_datatype() ->
+    ?LET(X, gen_maybe_blank_string(), {directory, X}).
+
+gen_flag_on_off() ->
+  elements(["on", "off"]).
+
+gen_simple_flag_datatype() ->
+    ?LET(Flag, gen_flag_on_off(),
+            {flag, Flag}).
+
+gen_complex_flag_datatype() ->
+    ?LET(A, gen_maybe_blank_string(),
+    ?LET(AV, gen_maybe_blank_string(),
+    ?LET(B, gen_maybe_blank_string(),
+    ?LET(BV, gen_maybe_blank_string(),
+         {flag, {flag, {A, AV}, {B, BV}}})))).
+
+gen_duration_uom() ->
+    elements([f, w, d, h, m, s, ms]).
+
+gen_duration_datatype() ->
+    ?LET(X, oneof([gen_maybe_blank_string(), int(), largeint(), real()]),
+         ?LET(Unit, gen_duration_uom(),
+              {{duration, Unit}, X})).
+
+gen_to_string_input() ->
+    oneof([gen_atom_datatype(),
+           gen_integer_datatype(),
+           gen_ip_datatype(),
+           gen_enum_datatype(),
+           gen_duration_datatype(),
+           gen_bytesize_datatype(),
+           gen_string_datatype(),
+           gen_filename_datatype(),
+           gen_simple_flag_datatype(),
+           gen_complex_flag_datatype()
+           ]).
+
+
+%% this EQC test doesn't have lots of "brains"
+%% basically, does to_string/2 throw an exception?
+prop_valid_to_string() ->
+    ?FORALL(Gen, gen_to_string_input(),
+              begin
+                {Type, Inputs} = Gen,
+                case cuttlefish_datatypes:to_string(Inputs, Type) of
+                  X when is_list(X) -> true;
+                  {error, Y} ->
+                    %% make sure we get the same error
+                    Y ==
+                      lists:flatten(
+                         io_lib:format( "Tried to convert ~p, an invalid datatype ~p to_string.", [Inputs, Type]));
+                  _ -> false
+                end
+              end).
+
+-endif.
+

--- a/test/cuttlefish_integration_test.erl
+++ b/test/cuttlefish_integration_test.erl
@@ -102,7 +102,7 @@ multibackend_test() ->
     ?assertEqual(10485760,            proplists:get_value(small_file_threshold, BitcaskProps)),
     ?assertEqual(-1,                  proplists:get_value(max_fold_age, BitcaskProps)),
     ?assertEqual(0,                   proplists:get_value(max_fold_puts, BitcaskProps)),
-    ?assertEqual(-1,                  proplists:get_value(expiry_secs, BitcaskProps)),
+    ?assertEqual(off,                 proplists:get_value(expiry_secs, BitcaskProps)),
     ?assertEqual(true,                proplists:get_value(require_hint_crc, BitcaskProps)),
     ?assertEqual(0,                   proplists:get_value(expiry_grace_time, BitcaskProps)),
     ?assertEqual(erlang,              proplists:get_value(io_mode, BitcaskProps)),

--- a/test/default.config
+++ b/test/default.config
@@ -243,7 +243,7 @@
              {small_file_threshold,10485760},
              {max_fold_age,-1},
              {max_fold_puts,0},
-             {expiry_secs,-1},
+             {expiry_secs,off},
              {require_hint_crc,true},
              {expiry_grace_time,0},
              {sync_strategy,none},

--- a/test/multi_backend.schema
+++ b/test/multi_backend.schema
@@ -244,9 +244,9 @@
 %%
 %% Default is: `-1` which disables automatic expiration
 {mapping, "multi_backend.$name.bitcask.expiry", "riak_kv.multi_backend", [
-  {datatype, {duration, s}},
+  {datatype, [{atom, off}, {duration, s}]},
   {level, advanced},
-  {default, -1}
+  {default, off}
 ]}.
 
 

--- a/test/riak.schema
+++ b/test/riak.schema
@@ -934,11 +934,11 @@ end}.
 %% set the `expiry_secs` option. If you needed to purge data automatically
 %% after 1 day, set the value to `1d`.
 %%
-%% Default is: `-1` which disables automatic expiration
+%% Default is: `off` which disables automatic expiration
 {mapping, "bitcask.expiry", "bitcask.expiry_secs", [
-  {datatype, {duration, s}},
+  {datatype, [{atom, off}, {duration, s}]},
   {level, advanced},
-  {default, -1}
+  {default, off}
 ]}.
 
 


### PR DESCRIPTION
add a >= 0 guard on from_string/2 for duration, bytesize, and port#. Update eunit test schemas accordingly. 
