### PR TITLE
RHS Sub unit testability

### DIFF
--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -22,11 +22,14 @@ render_template(FileName, Context) ->
     Str1 = re:replace(Str0, "\"", "\\\\\"", ReOpts),
 
     %% the mustache module is only available in the context of a rebar run.
-    case code:ensure_loaded(mustache) of
-        {module, mustache} ->
+    case {code:ensure_loaded(mustache), code:ensure_loaded(rebar_mustache)} of
+        {{module, mustache}, _} ->
             mustache:render(Str1, dict:from_list(Context));
+        {_, {module, rebar_mustache}} ->
+            rebar_mustache:render(Str1, dict:from_list(Context));
         _ ->
-            io:format("mustache module not loaded. this test can only be run in a rebar context~n")
+            io:format("mustache and/or rebar_mustache module not loaded. "
+                      "This test can only be run in a rebar context.~n")
     end.
 
 -spec generate_config(atom(), [string()]|string(), list()) -> list().

--- a/test/sample_mustache.schema
+++ b/test/sample_mustache.schema
@@ -1,0 +1,3 @@
+{mapping, "a.b", "app_a.setting_b", [
+  {default, "#(c)/{{mustache}}/a.b"}
+]}.


### PR DESCRIPTION
When writing the eunit tests for riak_kv, I noticed I had no way of including the mapping my `platform_bin_dir` depended on without reading in the riak_core schema. This PR allows you to pass in a schema that you can define in the test.
