### PR TITLE
Fiz dialyzer warnings and enable the untyped records warning

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 {require_otp_vsn, "R15|R16"}.
 
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info]}.
+{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
     {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
-    {neotoma, "1.7.1", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.1"}}}
+    {neotoma, "1.7.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.2"}}}
   ]}.
 
 {post_hooks, [{compile, "./rebar escriptize"}]}.

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -76,10 +76,10 @@ generate_file(Mappings, Filename) ->
     ConfFileLines = generate(Mappings),
 
     {ok, S} = file:open(Filename, [write]),
-    [ begin
+    _ = [ begin
           io:format(S, "~s~n", [lists:flatten(Line)])
       end || Line <- ConfFileLines],
-    file:close(S),
+    _ = file:close(S),
     ok.
 
 -spec generate_element(cuttlefish_mapping:mapping()) -> [string()].

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -28,6 +28,7 @@
 
 -type datatype() :: integer |
                     string |
+                    atom |
                     file |
                     directory |
                     flag |

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -395,7 +395,7 @@ transform_datatypes(Conf, Mappings) ->
                         {cuttlefish_util:levenshtein(VarName, MapVarName), MapVarName}
                     end || M <- Mappings],
                     Sorted = lists:sort(Possibilities),
-                    [ lager:warning("    ~s", [T]) || {_, T} <- lists:sublist(Sorted, 3) ],
+                    _ = [ lager:warning("    ~s", [T]) || {_, T} <- lists:sublist(Sorted, 3) ],
                     {Acc, ErrorAcc};
                 MappingRecord ->
                     DTs = cuttlefish_mapping:datatype(MappingRecord),
@@ -490,13 +490,13 @@ head_sub(Value) ->
 
 -spec transform_type(
         cuttlefish_datatypes:datatype_list(),
-        string()) -> {ok, term()} | [cuttlefish_error:errorlist()].
+        string()) -> {ok, term()} | cuttlefish_error:errorlist().
 transform_type(DTs, Value) ->
     transform_type(DTs, Value, []).
 
 -spec transform_type(
         cuttlefish_datatypes:datatype_list(),
-        string(), [cuttlefish_error:error()]) -> {ok, term()} | [cuttlefish_error:errorlist()].
+        string(), [cuttlefish_error:error()]) -> {ok, term()} | cuttlefish_error:errorlist().
 transform_type([], _, Errors) -> {error, Errors};
 transform_type([DT|DatatypeTail], Value, Errors) ->
     case {cuttlefish_datatypes:is_supported(DT), cuttlefish_datatypes:is_extended(DT)} of
@@ -513,7 +513,7 @@ transform_type([DT|DatatypeTail], Value, Errors) ->
                                cuttlefish_datatypes:datatype_list(),
                                any(),
                                [cuttlefish_error:error()]) ->
-                                     {ok, term()} | [cuttlefish_error:error()].
+                                     {ok, term()} | {'error', [cuttlefish_error:error()]}.
 transform_supported_type(DT, Tail, Value, ErrorAcc) ->
     case {DT, cuttlefish_datatypes:from_string(Value, DT)} of
         {_, {error, Message}} ->

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -513,7 +513,7 @@ transform_type([DT|DatatypeTail], Value, Errors) ->
                                cuttlefish_datatypes:datatype_list(),
                                any(),
                                [cuttlefish_error:error()]) ->
-                                     {ok, term()} | {'error', [cuttlefish_error:error()]}.
+                                     {ok, term()} | cuttlefish_error:errorlist().
 transform_supported_type(DT, Tail, Value, ErrorAcc) ->
     case {DT, cuttlefish_datatypes:from_string(Value, DT)} of
         {_, {error, Message}} ->

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -193,7 +193,7 @@ has_default(MappingRecord) ->
 -spec commented(mapping()) -> term().
 commented(M)        -> M#mapping.commented.
 
--spec datatype(mapping()) -> cuttlefish_datatypes:datatype().
+-spec datatype(mapping()) -> cuttlefish_datatypes:datatype_list().
 datatype(M) -> M#mapping.datatype.
 
 -spec level(mapping()) -> basic | intermediate | advanced.

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -48,12 +48,12 @@ files(ListOfSchemaFiles) ->
 strings(ListOfStrings) ->
     merger(fun string/2, ListOfStrings).
 
--spec merger(fun((string()) -> schema() | cuttlefish_error:errorlist()), [string()]) ->
+-spec merger(fun((string(), schema()) -> schema() | cuttlefish_error:errorlist()), [string()]) ->
                     schema() | cuttlefish_error:errorlist().
 merger(Fun, ListOfInputs) ->
     merger([ {Fun, Input} || Input <- ListOfInputs ]).
 
--spec merger([{fun((string()) -> schema() | cuttlefish_error:errorlist()), string()}]) ->
+-spec merger([{fun((string(), schema()) -> schema() | cuttlefish_error:errorlist()), string()}]) ->
                     schema() | cuttlefish_error:errorlist().
 merger(ListOfFunInputPairs) ->
     Schema = lists:foldr(
@@ -149,7 +149,7 @@ string(S, {T, M, V}) ->
                 0 ->
                     {Translations, Mappings, Validators};
                 _ ->
-                    [begin
+                    _ = [begin
                         case Desc of
                             [H|_] when is_list(H) ->
                                 [cuttlefish_error:print(D) || D <- Desc];

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -13,7 +13,7 @@ generate_templated_config(FileName, Conf, Context, PreexistingSchema) ->
         _ -> %% It's a list of lists, aka multiple strings
             [{ cuttlefish_schema:string_fun_factory(), render_template(F, Context)} || F <- FileName]
     end,
-    Schema = cuttlefish_schema:merger(RenderedSchemas ++ [ { fun(X, _) -> X end, PreexistingSchema} ]),
+    Schema = cuttlefish_schema:merger(RenderedSchemas ++ [ { fun(_, _) -> PreexistingSchema end, ""} ]),
     cuttlefish_generator:map(Schema, Conf).
 
 render_template(FileName, Context) ->
@@ -55,7 +55,7 @@ generate_config(SchemaFile, Conf) ->
 assert_valid_config({error, Phase, {error, Errors}}) ->
     %% What if Config is an error? It'd be nice to know what that was
     cuttlefish_error:print("Error in phase: ~s", [Phase]),
-    [ cuttlefish_error:print(E) || E <- Errors],
+    _ = [ cuttlefish_error:print(E) || E <- Errors],
     ?assert(false);
 assert_valid_config(List) when is_list(List) ->
     ok;
@@ -153,7 +153,7 @@ key_no_match(Key) ->
 dump_to_file(ErlangTerm, Filename) ->
     {ok, S} = file:open(Filename, [write,append]),
     io:format(S, "~p~n", [ErlangTerm]),
-    file:close(S),
+    _ = file:close(S),
     ok.
 
 -ifdef(TEST).

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -52,19 +52,21 @@ generate_config(SchemaFile, Conf) ->
     Schema = cuttlefish_schema:files([SchemaFile]),
     cuttlefish_generator:map(Schema, Conf).
 
-assert_valid_config({error, Phase, {error, Errors}}) ->
-    %% What if Config is an error? It'd be nice to know what that was
-    cuttlefish_error:print("Error in phase: ~s", [Phase]),
-    _ = [ cuttlefish_error:print(E) || E <- Errors],
-    ?assert(false);
-assert_valid_config(List) when is_list(List) ->
-    ok;
-assert_valid_config(_) ->
-    ?assert(false).
+assert_valid_config(Config) ->
+    case Config of
+        List when is_list(List) ->
+            ok;
+        {error, Phase, {error, Errors}} ->
+            erlang:exit({assert_valid_config_failed,
+                         [{phase, Phase},
+                          {error, Errors}]});
+        Other ->
+            erlang:exit({assert_valid_config_failed,
+                         [{bad_value, Other}]})
+    end.
 
-assert_config({error, _, _}=Config, _, _) ->
-    assert_valid_config(Config);
 assert_config(Config, Path, Value) ->
+    ok = assert_valid_config(Config),
     ActualValue = case path(cuttlefish_variable:tokenize(Path), Config) of
         {error, bad_nesting} ->
             ?assertEqual({Path, Value}, {Path, nesting_error});
@@ -74,17 +76,20 @@ assert_config(Config, Path, Value) ->
     end,
     ?assertEqual({Path, Value}, {Path, ActualValue}).
 
-assert_not_configured({error, _, _}=Config, _) ->
-    assert_valid_config(Config);
 assert_not_configured(Config, Path) ->
-    ActualValue = case path(cuttlefish_variable:tokenize(Path), Config) of
+    ok = assert_valid_config(Config),
+    case path(cuttlefish_variable:tokenize(Path), Config) of
         {error, bad_nesting} ->
-            ?assert(false);
-        {ok, _} ->
-            ?assert(false);
-        notset -> undefined
-    end,
-    ?assertEqual({Path, undefined}, {Path, ActualValue}).
+            erlang:exit({assert_not_configured_failed,
+                         [{bad_nesting, Path},
+                          {config, Config}]});
+        {ok, Value} ->
+            erlang:exit({assert_not_configured_failed,
+                         [{key, Path},
+                          {configured_to, Value},
+                          {config, Config}]});
+        notset -> ok
+    end.
 
 %% @doc Asserts that the generated configuration is in error.
 assert_error(Config) ->
@@ -116,9 +121,15 @@ assert_errors(Config, Phase, [H|_]=Messages) when is_list(H) ->
 %% @doc Asserts that the generated configuration is in error and
 %% contains the given error message.
 assert_error_message(Config, Message) ->
-    assert_error(Config),
+    ok = assert_error(Config),
     {error, Messages} = element(3, Config),
-    ?assert(lists:member({error, Message}, Messages)).
+    case lists:member({error, Message}, Messages) of
+        true -> ok;
+        false ->
+            erlang:exit({assert_error_message_failed,
+                         [{expected, Message},
+                          {actual, Messages}]})
+    end.
 
 
 -spec path(cuttlefish_variable:variable(),

--- a/src/lager_stderr_backend.erl
+++ b/src/lager_stderr_backend.erl
@@ -24,7 +24,10 @@
 -export([init/1, handle_call/2, handle_event/2, handle_info/2, terminate/2,
         code_change/3]).
 
--record(state, {level, formatter,format_config,colors=[]}).
+-record(state, {level :: {'mask', integer()},
+                formatter :: atom(),
+                format_config :: any(),
+                colors=[] :: list()}).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").

--- a/test/cuttlefish_lager_test_backend.erl
+++ b/test/cuttlefish_lager_test_backend.erl
@@ -14,7 +14,9 @@
         bounce/1]).
 
 %% holds the log messages for retreival on terminate
--record(state, {level, verbose, log = []}).
+-record(state, {level :: {mask, integer()},
+                verbose :: boolean(),
+                log = [] :: list()}).
 
 -include_lib("lager/include/lager.hrl").
 


### PR DESCRIPTION
This does not address the warnings generated by the ?assert macros used in cuttlefish_unit. I don't really know how to deal with those.

cc @joedevivo @seancribbs 
