### PR TITLE
Don't match return value when loading lager

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -66,7 +66,7 @@ parse_and_command(Args) ->
 
 %% @doc main method for generating erlang term config files
 main(Args) ->
-    ok = application:load(lager),
+    _ = application:load(lager),
 
     {Command, ParsedArgs, Extra} = parse_and_command(Args),
 


### PR DESCRIPTION
Lager may already be loaded so don't match against 'ok'.

I ran into this issue trying to run riak test. Here was output from trying to manually run chkconfig:

```
# /root/yz-verify/rt/riak_yz/dev/dev1/bin/riak chkconfig
Error generating config with cuttlefish
```

That doesn't say anything useful so then I ran `riak config effective`

```
# /root/yz-verify/rt/riak_yz/dev/dev1/bin/riak config effective
escript: exception error: no match of right hand side value {error,
                                                    {already_loaded,lager}}
  in function  cuttlefish_escript:main/1 (src/cuttlefish_escript.erl, line 69)
  in call from escript:run/2 (escript.erl, line 747)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_it/1 
  in call from init:start_em/1 
```
