### PR TITLE
Add support for -kernel net_ticktime

### DIFF
--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -243,3 +243,13 @@
   {datatype, integer},
   hidden
 ]}.
+
+%% @doc Set the net_kernel's net_ticktime.
+%%
+%% More information: http://www.erlang.org/doc/man/kernel_app.html#net_ticktime
+%% and http://www.erlang.org/doc/man/net_kernel.html#set_net_ticktime-1
+{mapping, "erlang.distribution.net_ticktime", "vm_args.-kernel net_ticktime", [
+  {commented, 60},
+  {datatype, integer},
+  hidden
+]}.

--- a/src/cuttlefish_vmargs.erl
+++ b/src/cuttlefish_vmargs.erl
@@ -32,7 +32,8 @@ stringify_test() ->
       {'-env ERL_FULLSWEEP_AFTER',"0"},
       {'-env ERL_CRASH_DUMP',"./log/erl_crash.dump"},
       {'-env ERL_MAX_ETS_TABLES',"256000"},
-      {'+P', "256000"}
+      {'+P', "256000"},
+      {'-kernel net_ticktime', "42"}
     ],
 
     VMArgs = stringify(VMArgsProplist),
@@ -48,7 +49,8 @@ stringify_test() ->
         "-env ERL_FULLSWEEP_AFTER 0",
         "-env ERL_CRASH_DUMP ./log/erl_crash.dump",
         "-env ERL_MAX_ETS_TABLES 256000",
-        "+P 256000"
+        "+P 256000",
+        "-kernel net_ticktime 42"
     ],
     [ ?assertEqual(E, V) || {E, V} <- lists:zip(Expected, VMArgs)],
     ok.

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -23,6 +23,7 @@ basic_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.+P", 256000),
     cuttlefish_unit:assert_not_configured(Config, "vm_args.+zdbbl"),
     cuttlefish_unit:assert_not_configured(Config, "vm_args.+sfwi"),
+    cuttlefish_unit:assert_not_configured(Config, "vm_args.-kernel net_ticktime"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_min"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_max"),
     case erlang:system_info(otp_release) of
@@ -55,7 +56,8 @@ override_schema_test() ->
         {["erlang", "distribution_buffer_size"], 1024},
         {["erlang", "schedulers", "force_wakeup_interval"], 500},
         {["erlang", "distribution", "port_range", "minimum"], 6000},
-        {["erlang", "distribution", "port_range", "maximum"], 7999}
+        {["erlang", "distribution", "port_range", "maximum"], 7999},
+        {["erlang", "distribution", "net_ticktime"], 43}
     ],
 
     Config = cuttlefish_unit:generate_templated_config(
@@ -75,6 +77,7 @@ override_schema_test() ->
     cuttlefish_unit:assert_config(Config, "vm_args.+sfwi", 500),
     cuttlefish_unit:assert_config(Config, "kernel.inet_dist_listen_min", 6000),
     cuttlefish_unit:assert_config(Config, "kernel.inet_dist_listen_max", 7999),
+    cuttlefish_unit:assert_config(Config, "vm_args.-kernel net_ticktime", 43),
 
     %% These settings are version dependent, so we won't even test them here
     %% because we don't know what version you're running, so we'll cover it


### PR DESCRIPTION
Partially addresses https://github.com/basho/riak_core/pull/489
