### PR TITLE
Better 'describe' command output, supersedes #134.

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -26,7 +26,8 @@
          generate_file/2,
          file/1,
          files/1,
-         is_variable_defined/2]).
+         is_variable_defined/2,
+         pretty_datatype/1]).
 
 -type conf_pair() :: {cuttlefish_variable:variable(), any()}.
 -type conf() :: [conf_pair()].

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -187,10 +187,24 @@ describe(ParsedArgs, Query) when is_list(Query) ->
     end,
     stop_deactivate().
 
+-ifndef(TEST).
 stop_deactivate() ->
     init:stop(1),
     timer:sleep(250),
     stop_deactivate().
+
+stop_ok() ->
+    init:stop(0).
+-endif.
+
+-ifdef(TEST).
+%% In test mode we don't want to kill the test VM prematurely.
+stop_deactivate() ->
+    error.
+
+stop_ok() ->
+    ok.
+-endif.
 
 generate(ParsedArgs) ->
     EtcDir = proplists:get_value(etc_dir, ParsedArgs),
@@ -230,7 +244,7 @@ generate(ParsedArgs) ->
             %% command EXCEPT '-args_file', so in order to get access to this file location
             %% from within the vm, we need to pass it in twice.
             ?STDOUT(" -config ~s -args_file ~s -vm_args ~s ", [AppConf, VMArgs, VMArgs]),
-            init:stop(0)
+            stop_ok()
     end.
 
 load_schema(ParsedArgs) ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -33,16 +33,16 @@
 cli_options() ->
 %% Option Name, Short Code, Long Code, Argument Spec, Help Message
 [
- {help,               $h, "help",        undefined,          "Print this usage page"},
- {etc_dir,            $e, "etc_dir",     {string, "/etc"},   "etc dir"},
- {dest_dir,           $d, "dest_dir",    string,             "specifies the directory to write the config file to"},
- {dest_file,          $f, "dest_file",   {string, "app"},    "the file name to write"},
- {schema_dir,         $s, "schema_dir",  string,             "a directory containing .schema files"},
- {schema_file,        $i, "schema_file", string,             "individual schema file, will be processed in command line order, after -s"},
- {conf_file,          $c, "conf_file",   string,             "a cuttlefish conf file, multiple files allowed"},
- {app_config,         $a, "app_config",  string,             "the advanced erlangy app.config"},
- {log_level,          $l, "log_level",   {string, "notice"}, "log level for cuttlefish output"},
- {print_schema,       $p, "print",       undefined,          "prints schema mappings on stderr"}
+ {help,         $h, "help",        undefined,          "Print this usage page"},
+ {etc_dir,      $e, "etc_dir",     {string, "/etc"},   "etc dir"},
+ {dest_dir,     $d, "dest_dir",    string,             "specifies the directory to write the config file to"},
+ {dest_file,    $f, "dest_file",   {string, "app"},    "the file name to write"},
+ {schema_dir,   $s, "schema_dir",  string,             "a directory containing .schema files"},
+ {schema_file,  $i, "schema_file", string,             "individual schema file, will be processed in command line order, after -s"},
+ {conf_file,    $c, "conf_file",   string,             "a cuttlefish conf file, multiple files allowed"},
+ {app_config,   $a, "app_config",  string,             "the advanced erlangy app.config"},
+ {log_level,    $l, "log_level",   {string, "notice"}, "log level for cuttlefish output"},
+ {print_schema, $p, "print",       undefined,          "prints schema mappings on stderr"}
 ].
 
 %% LOL! I wanted this to be halt 0, but honestly, if this escript does anything

--- a/test/cuttlefish_escript_test.erl
+++ b/test/cuttlefish_escript_test.erl
@@ -1,0 +1,100 @@
+-module(cuttlefish_escript_test).
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+-define(assertPrinted(___Text),
+        begin
+            ((fun() ->
+                     case cuttlefish_test_group_leader:get_output() of
+                         {ok, ___Output} ->
+                             case re:run(___Output, ___Text) of
+                                 {match, _} ->
+                                     ok;
+                                 nomatch ->
+                                     erlang:error({assertPrinted_failed,
+                                           [{module, ?MODULE},
+                                            {line, ?LINE},
+                                            {expected, ___Text},
+                                            {actual, unicode:characters_to_list(___Output)}]})
+                             end;
+                         error ->
+                             erlang:error({assertPrinted_failed,
+                                           [{module, ?MODULE},
+                                            {line, ?LINE},
+                                            {expected, ___Text},
+                                            {reason, timed_out_on_receive}]})
+                     end
+              end)())
+        end).
+
+-define(capturing(__Forms),
+        begin
+            ___OldLeader = group_leader(),
+            group_leader(cuttlefish_test_group_leader:new_group_leader(self()), self()),
+            try
+                __Forms
+            after
+                cuttlefish_test_group_leader:tidy_up(___OldLeader)
+            end
+        end).
+
+describe_test_() ->
+     [
+      {"`cuttlefish describe` prints documentation", fun describe_prints_docs/0},
+      {"`cuttlefish describe` prints datatype's valid values", fun describe_prints_datatype/0},
+      {"`cuttlefish describe` prints default", fun describe_prints_default/0},
+      {"`cuttlefish describe` prints configured value", fun describe_prints_configured/0},
+      {"`cuttlefish describe` prints erlang application key", fun describe_prints_app_key/0},
+      {"`cuttlefish describe` prints message when no default exists", fun describe_prints_no_default/0},
+      {"`cuttlefish describe` prints message when value not configured", fun describe_prints_not_configured/0}
+     ].
+
+describe(Key) ->
+    ?assertEqual(error, cuttlefish_escript:main(["-i", "../test/riak.schema", "-c", "../test/riak.conf", "describe", Key])).
+
+describe_prints_docs() ->
+    ?capturing(begin
+                   describe("ring_size"),
+                   ?assertPrinted("Documentation for ring_size"),
+                   ?assertPrinted("Default ring creation size\\.  Make sure it is a power of 2")
+               end).
+
+describe_prints_datatype() ->
+    ?capturing(begin 
+                   describe("storage_backend"),
+                   ?assertPrinted("- one of: bitcask, leveldb, memory, multi")
+               end).
+
+describe_prints_default() ->
+    ?capturing(begin
+                   describe("ring_size"),
+                   ?assertPrinted("Default Value : 64")
+               end).
+
+describe_prints_configured() ->
+    ?capturing(begin
+                   describe("anti_entropy"),
+                   ?assertPrinted("Set Value     : debug")
+               end).
+
+
+describe_prints_app_key() ->
+    ?capturing(begin
+                   describe("leveldb.bloomfilter"),
+                   ?assertPrinted("Internal key  : eleveldb\\.use_bloomfilter")
+               end).
+
+describe_prints_no_default() ->
+    ?capturing(begin
+                   describe("listener.https.foo"),
+                   ?assertPrinted("No default set")
+               end).
+
+describe_prints_not_configured() ->
+    ?capturing(begin
+                   describe("ssl.keyfile"),
+                   ?assertPrinted("Value not set in \\.\\./test/riak.conf")
+               end).
+
+-endif.

--- a/test/cuttlefish_test_group_leader.erl
+++ b/test/cuttlefish_test_group_leader.erl
@@ -1,0 +1,121 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2012 Basho Technologies, Inc.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_test_group_leader).
+
+-export([new_group_leader/1, 
+         group_leader_loop/2, 
+         tidy_up/1,
+         get_output/0]).
+
+%% @doc spawns the new group leader
+new_group_leader(Runner) ->
+    spawn_link(?MODULE, group_leader_loop, [Runner, queue:new()]).
+
+%% @doc listens for io_requests, and pipes them into an array
+group_leader_loop(Runner, Output) ->
+    receive
+        {io_request, From, ReplyAs, Req} ->
+            P = process_flag(priority, normal),
+            %% run this part under normal priority always
+            NewOutput = io_request(From, ReplyAs, Req, Output),
+            process_flag(priority, P),            
+            group_leader_loop(Runner, NewOutput);        
+        {get_output, Ref, From} ->
+            From ! {Ref, queue:to_list(Output)},
+            group_leader_loop(Runner, Output);
+        stab ->
+            kthxbye;
+        _ ->
+            %% discard any other messages
+            group_leader_loop(Runner, Output)
+    end.
+
+%% @doc closes group leader down
+tidy_up(FormerGroupLeader) ->
+    GroupLeaderToMurder = group_leader(),
+    group_leader(FormerGroupLeader, self()),
+    GroupLeaderToMurder ! stab.
+
+%% @doc Retrieves the io output from the group leader
+get_output() ->
+    GL = group_leader(),
+    Ref = make_ref(),
+    GL ! {get_output, Ref, self()},
+    receive
+        {Ref, Output} ->
+            {ok, Output}
+    after 1000 ->
+            error
+    end.
+
+%% Processes an io_request and sends a reply
+io_request(From, ReplyAs, Req, Output) ->
+    {Reply, NewOutput} = io_request(Req, Output),
+    io_reply(From, ReplyAs, Reply),
+    NewOutput.
+
+%% sends a reply back to the sending process
+io_reply(From, ReplyAs, Reply) ->
+    From ! {io_reply, ReplyAs, Reply}.
+
+%% If we're processing io:put_chars, Chars shows up as binary
+io_request({put_chars, Chars}, Output) when is_binary(Chars); is_list(Chars) ->
+    {ok, queue:in(Chars, Output)};
+io_request({put_chars, M, F, As}, Output) ->
+    try apply(M, F, As) of
+        Chars ->
+            {ok, queue:in(Chars, Output)}
+    catch
+        C:T -> {{error, {C,T,erlang:get_stacktrace()}}, Output}
+    end;
+io_request({put_chars, _Enc, Chars}, Output) ->
+    io_request({put_chars, Chars}, Output);
+io_request({put_chars, _Enc, Mod, Func, Args}, Output) ->
+    io_request({put_chars, Mod, Func, Args}, Output);
+%% The rest of these functions just handle expected messages from
+%% the io module. They're mostly i, but we only care about o.
+io_request({get_chars, _Enc, _Prompt, _N}, O) ->
+    {eof, O};
+io_request({get_chars, _Prompt, _N}, O) ->
+    {eof, O};
+io_request({get_line, _Prompt}, O) ->
+    {eof, O};
+io_request({get_line, _Enc, _Prompt}, O) ->
+    {eof, O};
+io_request({get_until, _Prompt, _M, _F, _As}, O) ->
+    {eof, O};
+io_request({setopts, _Opts}, O) ->
+    {ok, O};
+io_request(getopts, O) ->
+    {{error, enotsup}, O};
+io_request({get_geometry,columns}, O) ->
+    {{error, enotsup}, O};
+io_request({get_geometry,rows}, O) ->
+    {{error, enotsup}, O};
+io_request({requests, Reqs}, O) ->
+    {io_requests(Reqs, ok, O), O};
+io_request(_, O) ->
+    {{error, request}, O}.
+
+io_requests([R | Rs], ok, Output) ->
+    {Result, NewOutput} = io_request(R, Output),
+    io_requests(Rs, Result, NewOutput);
+io_requests(_, Result, Output) ->
+    {Result, Output}.


### PR DESCRIPTION
Example:

```
$ bin/riak config describe bitcask.expiry
Documentation for bitcask.expiry
By default, Bitcask keeps all of your data around. If your
data has limited time-value, or if for space reasons you need to
purge data, you can set the `expiry` option. If you needed to
purge data automatically after 1 day, set the value to `1d`.
Default is: `off` which disables automatic expiration

   Datatype     : [{atom,off},{duration,s}]
   Default Value: off
   Set Value    : undefined
   app.config   : bitcask.expiry_secs 
```

Also, sometimes the default value will be wrapped in quotes if it's a string. We need a better name for "app.config" too.

This pull-request's output looks more like this:

```
Documentation for bitcask.expiry
By default, Bitcask keeps all of your data around. If your
data has limited time-value, or if for space reasons you need to
purge data, you can set the `expiry` option. If you needed to
purge data automatically after 1 day, set the value to `1d`.
Default is: `off` which disables automatic expiration

   Valid Values: 
     - the text "off"
     - a time duration with units, e.g. '10s' for 10 seconds

   Default Value: off
   Set Value    : undefined
   Internal key : bitcask.expiry_secs
```
