### PR TITLE
Parser: Kill Trailing Comments

### DIFF
--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -36,8 +36,8 @@ line <- ((setting / comment / ws+) (crlf / eof)) / crlf %{
 
 %% A setting is a key and a value, joined by =, with surrounding
 %% whitespace ignored.
-setting <- ws* key ws* "=" ws* value ws* %{
-   [ _, Key, _, _Eq, _, Value, _ ] = Node,
+setting <- ws* key ws* "=" ws* value ws* comment? %{
+   [ _, Key, _, _Eq, _, Value, _, _ ] = Node,
    {Key, Value}
 %};
 
@@ -48,7 +48,7 @@ key <- head:word tail:("." word)* %{
 %};
 
 %% A value is any character, with trailing whitespace stripped.
-value <- (!(ws* crlf) .)+ `unicode:characters_to_list(iolist_to_binary(Node))`;
+value <- (!((ws* crlf) / comment) .)+ `unicode:characters_to_list(iolist_to_binary(Node))`;
 
 %% A comment is any line that begins with a # sign, leading whitespace
 %% allowed.

--- a/test/riak.conf
+++ b/test/riak.conf
@@ -1,4 +1,4 @@
-ring_size = 32
+ring_size = 32 # we want a smaller ring size
 anti_entropy = debug
 log.error.file = /var/log/error.log
 log.console.file = /var/log/console.log


### PR DESCRIPTION
Right now, everything on the RHS of the equal sign makes it into the Conf proplist value. We want to make sure trailing comments don't

e.g.

```
a.b.c = 6 # six is a good value
```

should not parse to

``` erlang
[{a, [{b, [ {c, "6 # six is a good value"}]}]}]
```

it should just be:

``` erlang
[{a, [{b, [ {c, "6"}]}]}]
```
