### PR TITLE
Enums: Should they be more like flags?

### DIFF
--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -168,12 +168,8 @@ to_string(Value, MaybeExtendedDatatype) ->
 from_string(Atom, atom) when is_atom(Atom) -> Atom;
 from_string(String, atom) -> list_to_atom(String);
 
-from_string(Atom, {enum, Enum}) when is_atom(Atom) ->
-    case lists:member(Atom, Enum) of
-        true -> Atom;
-        _ -> {error, lists:flatten(io_lib:format("~p is not a valid enum value, acceptable values are ~p.", [Atom, Enum]))}
-    end;
-from_string(String, {enum, Enum}) when is_list(String) -> from_string(list_to_atom(String), {enum, Enum});
+from_string(Value, {enum, Enum}) ->
+    cuttlefish_enum:parse(Value, {enum, Enum});
 
 from_string(Integer, integer) when is_integer(Integer) -> Integer;
 from_string(String, integer) when is_list(String) ->
@@ -284,7 +280,7 @@ from_string_ip_test() ->
     ok.
 
 from_string_enum_test() ->
-    ?assertEqual({error, "a is not a valid enum value, acceptable values are [b,c]."}, from_string(a, {enum, [b, c]})),
+    ?assertEqual({error, "\"a\" is not a valid enum value, acceptable values are [\"b\",\"c\"]."}, from_string(a, {enum, [b, c]})),
     ?assertEqual(true, from_string("true", {enum, [true, false]})),
     ?assertEqual(true, from_string(true, {enum, [true, false]})).
 

--- a/src/cuttlefish_enum.erl
+++ b/src/cuttlefish_enum.erl
@@ -62,15 +62,12 @@ to_string_by_key(Key, {enum, FriendlEnum}) ->
             to_error(Key, {enum, FriendlEnum})
     end.
 
--spec parse(term(), enum()
-           ) -> term() | cuttlefish_error:error().
+-spec parse(term(), enum()) -> term() | cuttlefish_error:error().
 parse(Value, {enum, RawEnum}) ->
     FriendlEnum = assuage_enum(RawEnum),
-    case parse_by_key(
-        atom_to_list_maybe(Value),
-        {enum, FriendlEnum})
-    of
-        {_Key, Val} -> Val;
+    case parse_by_key( atom_to_list_maybe(Value), {enum, FriendlEnum}) of
+        {_Key, Val} ->
+            Val;
         false ->
             parse_by_value(Value, {enum, FriendlEnum})
     end.

--- a/src/cuttlefish_enum.erl
+++ b/src/cuttlefish_enum.erl
@@ -1,0 +1,106 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_enum: datatype for simple enum settings with
+%%   customizable names and values
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_enum).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+-endif.
+
+-export([
+         to_string/2,
+         parse/2
+]).
+
+-define(FMT(F, A), lists:flatten(io_lib:format(F, A))).
+
+to_string(Atom, {enum, _}) when is_atom(Atom) ->
+    atom_to_list(Atom);
+to_string(Value, {enum, _}) ->
+    Value.
+
+-spec parse(string() | atom(),
+            {enum, [ atom() | string() | {atom()|string(), term()} ]}
+           ) -> term() | cuttlefish_error:error().
+parse(AtomValue, Enum) when is_atom(AtomValue) ->
+    parse(atom_to_list(AtomValue), Enum);
+parse(StrValue, {enum, RawEnum}) ->
+    FriendlEnum = assuage_enum(RawEnum),
+    case lists:keyfind(StrValue, 1, FriendlEnum) of
+        false ->
+            Acceptable = [Key || {Key, _} <- FriendlEnum],
+            {error, ?FMT("~p is not a valid enum value, acceptable values are ~p.", [StrValue, Acceptable])};
+        {_Key, Value} ->
+            Value
+    end.
+
+assuage_enum(Enum) ->
+    assuage_enum(Enum, []).
+assuage_enum([], FriendlEnum) ->
+    lists:reverse(FriendlEnum);
+%% If the head is a 2-tuple; yay!
+assuage_enum([{Key, Value}|EnumTail], FriendlEnum) when is_atom(Key) ->
+    assuage_enum(EnumTail, [ { cuttlefish_datatypes:to_string(Key, atom), Value } | FriendlEnum ]);
+assuage_enum([{Key, Value}|EnumTail], FriendlEnum) when is_list(Key) ->
+    assuage_enum(EnumTail, [ { Key, Value } | FriendlEnum ]);
+%% If the head is just a string or atom, fall here.
+assuage_enum([Key|EnumTail], FriendlEnum) when is_atom(Key) ->
+    assuage_enum(EnumTail, [
+            { cuttlefish_datatypes:to_string(Key, atom), Key } | FriendlEnum]);
+assuage_enum([Key|EnumTail], FriendlEnum) when is_list(Key) ->
+    assuage_enum(EnumTail, [{Key, Key} | FriendlEnum]);
+assuage_enum([BadTuple|_], _) when is_tuple(BadTuple) ->
+    {error, ?FMT("An enum element's tuple must be a 2-tuple and the first element must be an atom or a string. The value was: ~w", [BadTuple])};
+assuage_enum([ErroneousItem|_], _) ->
+    {error, ?FMT("An enum element needs to be a 2-tuple, a string, or an atom, but was: ~w", [ErroneousItem])}.
+
+-ifdef(TEST).
+
+parse_test() ->
+    ?assertEqual(1, parse("one", {enum, [{"one", 1}, two]})),
+    ?assertEqual(two, parse("two", {enum, [{"one", 1}, two]})),
+    ok.
+
+assuage_enum_test() ->
+    ?assertEqual([{"true", true}, {"false", false}],
+                 assuage_enum([true, false])),
+    ?assertEqual([{"true", "true"}, {"false", "false"}],
+                 assuage_enum(["true", "false"])),
+    ?assertEqual([{"one", 1}, {"two", 2}],
+                 assuage_enum([{one, 1}, {"two", 2}])),
+    ?assertEqual([{"off", off}, {"on", "On"}],
+                 assuage_enum([off, {on, "On"}])),
+    ok.
+
+assuage_enum_error_test() ->
+    ?assertEqual(
+       {error, "An enum element's tuple must be a 2-tuple and the first element must be an atom or a string. The value was: {one,two,three}"},
+       assuage_enum([{one, two, three}, oops])
+    ),
+    ?assertEqual(
+       {error, "An enum element needs to be a 2-tuple, a string, or an atom, but was: 7"},
+       assuage_enum([oops, 7])
+    ),
+    ok.
+
+-endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -31,7 +31,9 @@
         filter/1,
         errorlist_maybe/1,
         print/1,
-        print/2
+        print/2,
+        format/1,
+        format/2
 ]).
 
 -ifdef(TEST).
@@ -76,6 +78,13 @@ print(String) ->
         ok -> ok
     end.
 
+-spec format(io_lib:format()) -> error().
+format(Str) -> format(Str, []).
+
+-spec format(io_lib:format(), list()) -> error().
+format(Str, List) ->
+    {error, lists:flatten(io_lib:format(Str, List))}.
+
 -ifdef(TEST).
 
 is_error_test() ->
@@ -106,6 +115,11 @@ errorlist_maybe_test() ->
     ?assertEqual(
        ["hi", "what even is an error?", "bye"],
        errorlist_maybe(["hi", "what even is an error?", "bye"])),
+    ok.
+
+format_test() ->
+    ?assertEqual({error, "Hi!"}, format("Hi!")),
+    ?assertEqual({error, "Error: 17"}, format("Error: ~p", [17])),
     ok.
 
 -endif.

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -81,7 +81,7 @@ print(String) ->
 -spec format(io:format()) -> error().
 format(Str) -> format(Str, []).
 
--spec format(io_lib:format(), list()) -> error().
+-spec format(io:format(), list()) -> error().
 format(Str, List) ->
     {error, lists:flatten(io_lib:format(Str, List))}.
 

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -78,7 +78,7 @@ print(String) ->
         ok -> ok
     end.
 
--spec format(io_lib:format()) -> error().
+-spec format(io:format()) -> error().
 format(Str) -> format(Str, []).
 
 -spec format(io_lib:format(), list()) -> error().

--- a/src/cuttlefish_flag.erl
+++ b/src/cuttlefish_flag.erl
@@ -37,36 +37,19 @@
 -define(FMT(F, A), lists:flatten(io_lib:format(F, A))).
 
 parse(Value) ->
-    parse(Value, {flag, {on, true}, {off, false}}).
+    cuttlefish_enum:parse(Value, to_enum(flag)).
+parse(Value, Flag) ->
+    cuttlefish_enum:parse(Value, to_enum(Flag)).
 
-parse(Value, {flag, On, Off}) when is_atom(On), is_atom(Off) ->
-    parse(Value, {flag, {On, true}, {Off, false}});
-parse(Value, {flag, {On,OnValue}, {Off,OffValue}}) ->
-    AtomValue = cuttlefish_datatypes:from_string(Value, atom),
-    case AtomValue of
-        On -> OnValue;
-        Off -> OffValue;
-        _ -> {error, ?FMT("invalid value ~p for flag, valid values are ~p or"
-                          " ~p", [Value, On, Off])}
-    end.
-
-to_string(Value, Flag) when is_list(Value) ->
-    to_string(list_to_atom(Value), Flag);
-to_string(Value, flag) ->
-    to_string(Value, {flag, {on, true}, {off, false}});
-to_string(On, {flag, {On, _}, _}) ->
-    atom_to_list(On);
-to_string(OnValue, {flag, {On, OnValue}, _}) when is_atom(On) ->
-    atom_to_list(On);
-to_string(Off, {flag, _, {Off, _}}) when is_atom(Off) ->
-    atom_to_list(Off);
-to_string(OffValue, {flag, _, {Off, OffValue}}) when is_atom(Off) ->
-    atom_to_list(Off);
-to_string(Value, {flag, On, Off}) ->
-    to_string(Value, {flag, {On, true}, {Off, false}});
 to_string(Value, Flag) ->
-    {error, ?FMT("could not convert '~p' of type ~p to a string", [Value, Flag])}.
+    cuttlefish_enum:to_string(Value, to_enum(Flag)).
 
+to_enum({flag, {On, OnValue}, {Off, OffValue}}) ->
+    {enum, [{On, OnValue}, {Off, OffValue}]};
+to_enum({flag, On, Off}) ->
+    {enum, [{On, true}, {Off, false}]};
+to_enum(flag) ->
+    {enum, [{on, true}, {off, false}]}.
 
 -ifdef(TEST).
 parse_test() ->
@@ -108,5 +91,4 @@ to_string_test() ->
     ?assertEqual(to_string(simple, {flag, {simple, ok},
                                {foo, {long, tuple, value}}}),
                  "simple").
-
 -endif.

--- a/test/cuttlefish_nested_schema_test.erl
+++ b/test/cuttlefish_nested_schema_test.erl
@@ -1,0 +1,61 @@
+-module(cuttlefish_nested_schema_test).
+
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+nested_schema_test() ->
+    Conf = [
+        {["thing", "a"], on},
+        {["nested", "thing1", "type"], "thing"},
+        {["nested", "thing1", "thing", "a"], off},
+        {["nested", "thing2", "type"], "thing"}
+    ],
+    Config = cuttlefish_generator:map(schema(), Conf),
+    ?assertEqual(
+        [{thing, [{a, true}]},
+         {nested_things, [{thing, [{a, false}]}, {thing, [{a, true}]}]}],
+         Config
+        ),
+    ok.
+
+schema() ->
+    Mappings = [
+        {mapping, "thing.a", "thing.a", [
+            {datatype, flag},
+            {default, on}
+        ]},
+        {mapping, "nested.$name.type", "nested_things", [
+            {datatype, {enum, [thing]}}
+        ]},
+        {mapping, "nested.$name.thing.a", "nested_things", [
+            {datatype, flag},
+            {default, on}
+        ]}
+    ],
+    Translations = [
+        {translation, "nested_things",
+        fun(Conf, Schema) ->
+            NestedNames = cuttlefish_variable:fuzzy_matches(["nested","$name","type"], Conf),
+            Things = [ begin
+                ConfigName = ["nested", Name],
+                Prefix = ConfigName ++ ["thing"],
+                SubConf = [ begin
+                    {Key -- ConfigName, Value}
+                end || {Key, Value} <- cuttlefish_variable:filter_by_prefix(Prefix, Conf)],
+
+                Proplist = cuttlefish_generator:map(Schema, SubConf),
+                case cuttlefish_error:is_error(Proplist) of
+                    true -> cuttlefish:invalid("gtfo");
+                    _ -> {thing, proplists:get_value(thing, Proplist)}
+                end
+            end|| {"$name", Name} <- NestedNames],
+            case Things of
+                [] -> cuttlefish:unset();
+                _ -> Things
+            end
+        end}
+    ],
+    {
+        [ cuttlefish_translation:parse(T) || T <- Translations],
+        [ cuttlefish_mapping:parse(M) || M <- Mappings],
+        []}.


### PR DESCRIPTION
Imagine

``` erlang
%% @doc Specifies the storage engine used for Riak's key-value data
%% and secondary indexes (if supported).
{mapping, "storage_backend", "riak_kv.storage_backend", [
  {default, {{storage_backend}} },
  {datatype, {enum, [bitcask, leveldb, memory, multi]}}
]}.

{translation,
 "riak_kv.storage_backend",
 fun(Conf) ->
    Setting = cuttlefish:conf_get("storage_backend", Conf),
    case Setting of
      bitcask -> riak_kv_bitcask_backend;
      leveldb -> riak_kv_eleveldb_backend;
      memory -> riak_kv_memory_backend;
      multi -> riak_kv_multi_backend;
      _Default -> riak_kv_bitcask_backend
    end
 end}.
```

Now imagine if it were just:

``` erlang
%% @doc Specifies the storage engine used for Riak's key-value data
%% and secondary indexes (if supported).
{mapping, "storage_backend", "riak_kv.storage_backend", [
  {default, {{storage_backend}} },
  {datatype, {enum, [
      {bitcask, riak_kv_bitcask_backend}, 
      {leveldb, riak_kv_eleveldb_backend}, 
      {memory, riak_kv_memory_backend}, 
      {multi, riak_kv_multi_backend}
    ]}}
]}.
```
