### PR TITLE
effective config doesn't include advanced.config mods

### DIFF
--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -1,0 +1,166 @@
+%% -------------------------------------------------------------------
+%%
+%% cuttlefish_effective: handles datatypes in cuttlefish schemas
+%%
+%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+-module(cuttlefish_effective).
+
+-define(FMT(F,A), lists:flatten(io_lib:format(F,A))).
+
+-export([build/3]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+-endif.
+
+-spec build(cuttlefish_conf:conf(), cuttlefish_schema:schema(), [proplists:property()]) -> [string()].
+build(Conf, {_Translations, Mappings, _Validators} = _Schema, AdvConfig) ->
+    EffectiveConfig = lists:reverse(lists:sort(cuttlefish_generator:add_defaults(Conf, Mappings))),
+    %% EffectiveConfig is a list of { [string()], term()}
+
+    KeysToHateOn = process_advanced(Mappings, AdvConfig),
+
+    lists:foldl(
+        fun({Var, Value}, Acc) ->
+            Variable = string:join(Var, "."),
+
+            IsHater =
+                lists:any(
+                    fun(X) ->
+                        cuttlefish_variable:is_fuzzy_match(Var, X)
+                    end,
+                    KeysToHateOn
+                    ),
+
+            Line = try ?FMT("~s = ~s", [Variable, Value]) of
+                X -> X
+            catch
+                _:_ ->
+                    %% I hate that I had to do this, 'cause you know...
+                    %% Erlang and Strings, but actually this is ok because
+                    %% sometimes there are going to be weird tuply things
+                    %% in here, so always good to fall back on ~p.
+                    %% honestly, I think this try should be built into io:format
+                    ?FMT("~s = ~p", [Variable, Value])
+            end,
+            case IsHater of
+                true ->
+                    [?FMT("## ~s was overridden in advanced.config", [Variable]),
+                     "## " ++ Line] ++ Acc;
+                _ -> [Line | Acc]
+            end
+        end,
+        [],
+        EffectiveConfig
+    ).
+
+-spec process_advanced([cuttlefish_mapping:mapping()], [proplists:property()]) -> [cuttlefish_variable:variable()].
+process_advanced(Mappings, AdvancedConfig) ->
+    AdvKeys = proplist_to_kvcpaths(AdvancedConfig),
+    lists:foldl(
+        fun(M, Acc) ->
+            case lists:member(cuttlefish_mapping:mapping(M), AdvKeys) of
+                true ->
+                    [cuttlefish_mapping:variable(M)|Acc];
+                _ -> Acc
+            end
+        end,
+        [],
+        Mappings).
+
+proplist_to_kvcpaths(Proplist) ->
+    proplist_to_kvcpaths("", Proplist).
+proplist_to_kvcpaths(Prefix, Proplist) ->
+    NewPrefix = case Prefix of
+        "" -> "";
+        _ -> Prefix ++ "."
+    end,
+    lists:foldl(fun(K, Acc) ->
+            KeyedPrefix = NewPrefix ++ atom_to_list(K),
+            R = proplist_to_kvcpaths(
+                KeyedPrefix,
+                proplists:get_value(K, Proplist)),
+            case R of
+                [] ->
+                    [KeyedPrefix|Acc];
+                _ ->
+                    Acc ++ R
+            end
+        end,
+        [],
+        keys_if_you_got_em(Proplist)
+    ).
+
+%% For EffectiveConfig
+%% 1. build a list of "leaf" key combos for AdvConfig
+%% 2. Search mappings for possible matches
+%% 3. If match, comment out
+
+keys_if_you_got_em(Proplist) when is_list(Proplist) ->
+    proplists:get_keys(Proplist);
+keys_if_you_got_em(_) -> [].
+
+-ifdef(TEST).
+
+process_advanced_test() ->
+    Mappings = [
+        cuttlefish_mapping:parse(
+            {mapping, "thing.1", "a.b.c", []}
+        )
+    ],
+    AdvConfig = [{a, [{b, [{c, ""}, {d, ""}]}]}],
+    KeysToWatch = process_advanced(Mappings, AdvConfig),
+    ?assertEqual(["a.b.c"], KeysToWatch),
+    ok.
+
+proplist_to_kvcpath_test() ->
+    Proplist = [{a, [
+                    {b, [
+                        {c, "x"}
+                        ]},
+                    {d, [
+                        {e, "y"}
+                        ]},
+                    {f , "z"}
+                    ]
+                },
+                {g, "q"}],
+    Paths = proplist_to_kvcpaths(Proplist),
+    ?assertEqual([
+        "a.b.c",
+        "a.d.e",
+        "a.f",
+        "g"
+    ], Paths),
+    ok.
+
+proplists_to_kvcpath_riak_core_test() ->
+    Proplist = [{riak_core,[
+        {ring_creation_size,128},
+        {cluster_mgr, {"127.0.0.1", 9080 } }
+    ]}],
+    Paths = proplist_to_kvcpaths(Proplist),
+    ?assertEqual([
+        "riak_core.ring_creation_size",
+        "riak_core.cluster_mgr"
+    ], Paths),
+    ok.
+
+-endif.

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -2,7 +2,7 @@
 %%
 %% cuttlefish_effective: handles generating the effective configuration
 %%
-%% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
+%% Copyright (c) 2014 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -1,6 +1,6 @@
 %% -------------------------------------------------------------------
 %%
-%% cuttlefish_effective: handles datatypes in cuttlefish schemas
+%% cuttlefish_effective: handles generating the effective configuration
 %%
 %% Copyright (c) 2013 Basho Technologies, Inc.  All Rights Reserved.
 %%

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -120,7 +120,7 @@ effective(ParsedArgs) ->
         load_conf(ParsedArgs),
         load_schema(ParsedArgs),
         AdvConfig),
-    [ ?STDOUT(Line, []) || Line <- EffectiveConfig],
+    _ = [ ?STDOUT(Line, []) || Line <- EffectiveConfig],
     ok.
 
 %% This is the function that dumps the docs for a single setting


### PR DESCRIPTION
This is a tricky one, I'd like to get one of the following solutions in for riak's 2.0 release:
### Option 1

simply cat the advanced.config at the end of the output of the effective conf. It will at least indicate to the user that these values are detected and being used.
### Option 2

Since we know which app.config values a cuttlefish variable will effect, we could include some kind of indicator that it is overridden in advanced.config.

e.g.

```
some.setting.a = on
## some.setting.b is overriden in advanced.config's 'erlang_library.variable'
## some.setting.b = off
```

I think this option is more friendly to commandline querying of effective confs. grep etc...
