### PR TITLE
Test: UTF-8 vs latin-1 regression

### DIFF
--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -48,7 +48,15 @@ key <- head:word tail:("." word)* %{
 %};
 
 %% A value is any character, with trailing whitespace stripped.
-value <- (!((ws* crlf) / comment) .)+ `unicode:characters_to_list(iolist_to_binary(Node))`;
+value <- (!((ws* crlf) / comment) .)+ %{
+  case
+    lists:any(fun(X) -> byte_size(X) > 1 end, lists:flatten(Node)) of
+    true ->
+      {error, lists:flatten(io_lib:format("Error converting value on line #~p to latin1", [line(Idx)]))};
+    false ->
+      unicode:characters_to_list(iolist_to_binary(Node))
+  end
+%};
 
 %% A comment is any line that begins with a # sign, leading whitespace
 %% allowed.
@@ -113,7 +121,7 @@ ws <- [ \t] `ws`;
 %% Other modules in this application interpret and validate the
 %% result of a successful parse.
 %% @end
-
+-define(line, true).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -22,23 +22,23 @@
 
 %% A configuration file may have zero-or-more lines.
 config <- line* %{
-  [ L || L <- Node, is_setting(L) ]
+    [ L || L <- Node, is_setting(L) ]
 %};
 
 %% Lines are actual settings, comments, or horizontal whitespace,
 %% terminated by an end-of-line or end-of-file.
 line <- ((setting / comment / ws+) (crlf / eof)) / crlf %{
-  case Node of
-     [ Line, _EOL ] -> Line;
-      Line -> Line
-  end
+    case Node of
+        [ Line, _EOL ] -> Line;
+        Line -> Line
+    end
 %};
 
 %% A setting is a key and a value, joined by =, with surrounding
 %% whitespace ignored.
 setting <- ws* key ws* "=" ws* value ws* comment? %{
-   [ _, Key, _, _Eq, _, Value, _, _ ] = Node,
-   {Key, Value}
+    [ _, Key, _, _Eq, _, Value, _, _ ] = Node,
+    {Key, Value}
 %};
 
 %% A key is a series of dot-separated identifiers.
@@ -49,13 +49,12 @@ key <- head:word tail:("." word)* %{
 
 %% A value is any character, with trailing whitespace stripped.
 value <- (!((ws* crlf) / comment) .)+ %{
-  case
-    unicode:characters_to_binary(Node, utf8, latin1) of
-    {_Status, _Begining, _Rest} ->
-      {error, lists:flatten(io_lib:format("Error converting value on line #~p to latin1", [line(Idx)]))};
-    Bin ->
-      binary_to_list(Bin)
-  end
+    case unicode:characters_to_binary(Node, utf8, latin1) of
+        {_Status, _Begining, _Rest} ->
+            {error, ?FMT("Error converting value on line #~p to latin1", [line(Idx)])};
+        Bin ->
+            binary_to_list(Bin)
+    end
 %};
 
 %% A comment is any line that begins with a # sign, leading whitespace
@@ -122,6 +121,8 @@ ws <- [ \t] `ws`;
 %% result of a successful parse.
 %% @end
 -define(line, true).
+-define(FMT(F,A), lists:flatten(io_lib:format(F,A))).
+
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
@@ -142,8 +143,7 @@ unescape_dots([C|Rest]) ->
 -ifdef(TEST).
 file_test() ->
     Conf = conf_parse:file("../test/riak.conf"),
-    ?assertEqual(
-    [
+    ?assertEqual([
             {["ring_size"],"32"},
             {["anti_entropy"],"debug"},
             {["log","error","file"],"/var/log/error.log"},
@@ -151,8 +151,14 @@ file_test() ->
             {["log","syslog"],"on"},
             {["listener","http","internal"],"127.0.0.1:8098"},
             {["listener","http","external"],"10.0.0.1:80"}
-    ],
-    Conf),
+        ], Conf),
+    ok.
+
+utf8_test() ->
+    Conf = conf_parse:parse("setting = thingŒ\n"),
+    ?assertEqual([{["setting"],
+            {error, "Error converting value on line #1 to latin1"}
+        }], Conf),
     ok.
 -endif.
 %}

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -50,11 +50,11 @@ key <- head:word tail:("." word)* %{
 %% A value is any character, with trailing whitespace stripped.
 value <- (!((ws* crlf) / comment) .)+ %{
   case
-    lists:any(fun(X) -> byte_size(X) > 1 end, lists:flatten(Node)) of
-    true ->
+    unicode:characters_to_binary(Node, utf8, latin1) of
+    {_Status, _Begining, _Rest} ->
       {error, lists:flatten(io_lib:format("Error converting value on line #~p to latin1", [line(Idx)]))};
-    false ->
-      unicode:characters_to_list(iolist_to_binary(Node))
+    Bin ->
+      binary_to_list(Bin)
   end
 %};
 

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -38,7 +38,7 @@
 is_variable_defined(VariableDef, Conf) ->
     lists:any(fun({X, _}) -> cuttlefish_variable:is_fuzzy_match(X, VariableDef) end, Conf).
 
--spec files([file:name()]) -> conf() | cuttlefish_error:error_list().
+-spec files([file:name()]) -> conf() | cuttlefish_error:errorlist().
 files(ListOfConfFiles) ->
     {ValidConf, Errors} = lists:foldl(
       fun(ConfFile, {ConfAcc, ErrorAcc}) ->
@@ -61,7 +61,7 @@ files(ListOfConfFiles) ->
         _ -> {error, Errors}
     end.
 
--spec file(file:name()) -> conf() | cuttlefish_error:error_list().
+-spec file(file:name()) -> conf() | cuttlefish_error:errorlist().
 file(Filename) ->
     case conf_parse:file(Filename) of
         {error, Reason} ->

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -306,7 +306,7 @@ load_conf(ParsedArgs) ->
     lager:debug("ConfFiles: ~p", [ConfFiles]),
     case cuttlefish_conf:files(ConfFiles) of
         {error, Errors} ->
-            [ lager:error(E) || {error, E} <- Errors],
+            _ = [ lager:error(E) || {error, E} <- Errors],
             stop_deactivate(),
             {error, Errors};
         GoodConf ->

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -122,7 +122,7 @@ count_mappings(Mappings) ->
 file(Filename, Schema) ->
     {ok, B} = file:read_file(Filename),
     %% TODO: Hardcoded utf8
-    S = unicode:characters_to_list(B, utf8),
+    S = unicode:characters_to_list(B, latin1),
     case string(S, Schema) of
         {error, Errors} ->
             cuttlefish_error:print("Error parsing schema: ~s", [Filename]),

--- a/src/cuttlefish_schema.erl
+++ b/src/cuttlefish_schema.erl
@@ -121,7 +121,8 @@ count_mappings(Mappings) ->
 -spec file(string(), schema()) -> schema() | cuttlefish_error:errorlist().
 file(Filename, Schema) ->
     {ok, B} = file:read_file(Filename),
-    %% TODO: Hardcoded utf8
+    %% latin-1 is easier to support generically. We'll revisit utf-8
+    %% support in the future.
     S = unicode:characters_to_list(B, latin1),
     case string(S, Schema) of
         {error, Errors} ->

--- a/test/cuttlefish_escript_integration_tests.erl
+++ b/test/cuttlefish_escript_integration_tests.erl
@@ -3,6 +3,20 @@
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 
+escript_utf8_test() ->
+    cuttlefish_lager_test_backend:bounce(error),
+
+    ?assertThrow(stop_deactivate, cuttlefish_escript:main(
+              "-d ../test_fixtures/escript_utf8_test/generated.config "
+              "-s ../test_fixtures/escript_utf8_test/lib "
+              "-e ../test_fixtures/escript_utf8_test/etc "
+              "-c ../test_fixtures/escript_utf8_test/etc/utf8.conf generate"
+            )),
+    [Log] = cuttlefish_lager_test_backend:get_logs(),
+    ?assertMatch({match, _}, re:run(Log, "utf8.conf: Error converting value on line #1 to latin1")),
+    ok.
+
+
 escript_prune_test_() ->
     {timeout, 20, [
                    escript_prune("-m 3", 3),

--- a/test/cuttlefish_escript_test.erl
+++ b/test/cuttlefish_escript_test.erl
@@ -51,7 +51,7 @@ describe_test_() ->
      ].
 
 describe(Key) ->
-    ?assertEqual(error, cuttlefish_escript:main(["-i", "../test/riak.schema", "-c", "../test/riak.conf", "describe", Key])).
+    ?assertThrow(stop_deactivate, cuttlefish_escript:main(["-i", "../test/riak.schema", "-c", "../test/riak.conf", "describe", Key])).
 
 describe_prints_docs() ->
     ?capturing(begin
@@ -61,7 +61,7 @@ describe_prints_docs() ->
                end).
 
 describe_prints_datatype() ->
-    ?capturing(begin 
+    ?capturing(begin
                    describe("storage_backend"),
                    ?assertPrinted("- one of: bitcask, leveldb, memory, multi")
                end).

--- a/test_fixtures/escript_utf8_test/etc/utf8.conf
+++ b/test_fixtures/escript_utf8_test/etc/utf8.conf
@@ -1,0 +1,1 @@
+setting = thingŒ

--- a/test_fixtures/escript_utf8_test/lib/01-setting.schema
+++ b/test_fixtures/escript_utf8_test/lib/01-setting.schema
@@ -1,0 +1,1 @@
+{mapping, "setting", "setting", []}.


### PR DESCRIPTION
We need to determine wether or not Riak 1.4's app.config and vm.args file could accept UTF-8 values or if they are restricted to latin-1. For example, multi backend bucket names.

If riak 1.4 can accept UTF-8 values, cuttlefish needs to be able to as well. If they can't , then it's desirable for cuttlefish to be able to detect non latin1 files and print an error message, but that might be a 2.0.1 fix.
