### PR TITLE
Support OTP 17.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R15|R16"}.
+{require_otp_vsn, "R15|R16|17"}.
 
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 


### PR DESCRIPTION
Hello,
I'd like to use cuttlefish with `OTP 17.0`. So I modified the `require_otp_vsn` at `rebar.config`.
Thank you
