### PR TITLE
Edoc cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ deps:
 	./rebar get-deps
 
 docsclean:
-	@rm -rf doc/*.png doc/*.html doc/*.css edoc-info
+	@rm -rf doc/*.png doc/*.html doc/*.css doc/edoc-info
 
 compile: deps
 	./rebar compile

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -102,20 +102,22 @@ ws <- [ \t] `ws`;
 %%
 %% -------------------------------------------------------------------
 
-%% @doc This module implements the parser for a sysctl-style
+%% This module implements the parser for a sysctl-style
 %% configuration format. Example:
 %%
+%% ```
 %% riak.local.node = riak@127.0.0.1
 %% riak.local.http = 127.0.0.1:8098
 %% riak.local.pb = 127.0.0.1:8087
-%% riak.local.storage.backend = bitcask
+%% riak.local.storage.backend = bitcask'''
 %%
 %% This would parse into the following flat proplist:
 %%
+%% ```
 %% [{<<"riak.local.node">>,<<"riak@127.0.0.1">>},
 %% {<<"riak.local.http">>,<<"127.0.0.1:8098">>},
 %% {<<"riak.local.pb">>,<<"127.0.0.1:8087">>},
-%% {<<"riak.local.storage.backend">>,<<"bitcask">>}]
+%% {<<"riak.local.storage.backend">>,<<"bitcask">>}]'''
 %%
 %% Other modules in this application interpret and validate the
 %% result of a successful parse.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -36,7 +36,7 @@
     otp/3
 ]).
 
-% @doc If DesiredMinimum =< the OTP you're running, then return
+% @doc If DesiredMinimum =&lt; the OTP you're running, then return
 % IfGreaterOrEqual, otherwise IfLessThan.
 -spec otp(string(), any(), any()) -> any().
 otp(DesiredMinimumOTPVersion, IfGreaterOrEqual, IfLessThan) ->


### PR DESCRIPTION
- `Makefile`: properly remove `edoc-info` file
- `conf_parse`: temporarily(?) remove module doc because generated file order is incorrect
- `conf_parse`: fix formatting on configuration snippets in case module doc is reinstated
- `cuttlefish`: escape less-than
