### PR TITLE
Changed default for sfwi to enabled, rather than commented.

### DIFF
--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -217,7 +217,7 @@
 %%
 %% More information: http://www.erlang.org/doc/man/erl.html#+sfwi
 {mapping, "erlang.schedulers.force_wakeup_interval", "vm_args.+sfwi", [
-  {commented, 500},
+  {default, 500},
   {datatype, integer}
 ]}.
 


### PR DESCRIPTION
I've been doing a little git and email archaeology to see if there's a rationale anyplace for no longer shipping with +sfwi #### — I couldn't find one. Given scheduler collapse can still occur on R16 given badly behaved BIFs or long-running NIFs (no dirty_schedulers, that's an R17 feature) we should probably still ship with this configured by default.
