### PR TITLE
+a is missing from erlang_vm.schema

### DIFF
--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -137,10 +137,15 @@
   hidden
 ]}.
 
-{validator, "stack-size-divisible", "must be divisible by the system word-size",
+{validator, "stack-size-divisible", ("must be divisible by " ++ integer_to_list(erlang:system_info({wordsize,external}))),
  fun(X) -> X rem (erlang:system_info({wordsize, external})) == 0 end}.
 
-{validator, "stack-size-range", "must be in the range of (16..8192) * 1024 * system word-size",
+{validator, "stack-size-range",
+ begin
+     WordSize = erlang:system_info({wordsize, external}),
+     ("must be in the range of " ++ cuttlefish_bytesize:to_string(16 * 1024 * WordSize)
+      ++ " to " ++ cuttlefish_bytesize:to_string(8192 * 1024 * WordSize))
+ end,
  fun(X) ->
    Scaled = X div (1024 * erlang:system_info({wordsize, external})),
    Scaled =< 8192 andalso Scaled >= 16

--- a/priv/erlang_vm.schema
+++ b/priv/erlang_vm.schema
@@ -120,6 +120,38 @@
 {validator, "range:0-1024", "must be 0 to 1024",
  fun(X) -> X >= 0 andalso X =< 1024 end}.
 
+%% @doc Suggested stack size, in bytes, for threads in the
+%% async-thread pool. Valid range is 16-8192 kilowords. The default
+%% suggested stack size is 16 kilowords, i.e, 64 kilobyte on 32-bit
+%% architectures. This small default size has been chosen since the
+%% amount of async-threads might be quite large. The default size is
+%% enough for drivers delivered with Erlang/OTP, but might not be
+%% sufficiently large for other dynamically linked in drivers that use
+%% the driver_async() functionality. Note that the value passed is
+%% only a suggestion, and it might even be ignored on some platforms.
+%%
+%% More information at: http://erlang.org/doc/man/erl.html
+{mapping, "erlang.async_threads.stack_size", "vm_args.+a", [
+  {datatype, bytesize},
+  {validators, [ "stack-size-divisible", "stack-size-range"]},
+  hidden
+]}.
+
+{validator, "stack-size-divisible", "must be divisible by the system word-size",
+ fun(X) -> X rem (erlang:system_info({wordsize, external})) == 0 end}.
+
+{validator, "stack-size-range", "must be in the range of (16..8192) * 1024 * system word-size",
+ fun(X) ->
+   Scaled = X div (1024 * erlang:system_info({wordsize, external})),
+   Scaled =< 8192 andalso Scaled >= 16
+ end}.
+
+{translation, "vm_args.+a",
+ fun(Conf) ->
+   RawValue = cuttlefish:conf_get("erlang.async_threads.stack_size", Conf),
+   RawValue div (1024 * erlang:system_info({wordsize, external}))
+ end}.
+
 %% Note: OTP R15 and earlier uses -env ERL_MAX_PORTS, R16+ uses +Q
 %% @doc The number of concurrent ports/sockets
 %% Valid range is 1024-134217727

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -595,7 +595,7 @@ run_validations({_, Mappings, Validators}, Conf) ->
                     LogString = ?FMT(
                         "~s invalid, ~s",
                         [
-                            cuttlefish_mapping:variable(M),
+                            cuttlefish_variable:format(cuttlefish_mapping:variable(M)),
                             cuttlefish_validator:description(V)
                         ]),
                     lager:error(LogString),

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -252,7 +252,7 @@ filter_by_variable_starts_with_test() ->
     ok.
 
 variable_roundtrip_test() ->
-   ?assert(eqc:quickcheck(eqc:testing_time(3, eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
+   ?assert(eqc:quickcheck(eqc:numtests(200,eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
 
 prop_format_tokenize_roundtrip() ->
     ?FORALL(Variable, non_empty(list(gen_word())),

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -25,11 +25,15 @@
 -export_type([variable/0]).
 
 -ifdef(TEST).
+-ifdef(EQC).
+-include_lib("eqc/include/eqc.hrl").
+-endif.
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 -endif.
 
 -export([
+     format/1,
      tokenize/1,
      split_on_match/1,
      replace_match/2,
@@ -38,6 +42,14 @@
      is_fuzzy_match/2,
      filter_by_prefix/2
 ]).
+
+%% @doc Formats a variable back into its dot-separated version.
+%% Inverse of tokenize/1.
+-spec format(variable()) -> string().
+format(Key=[H|_]) when is_list(H) ->
+    Escaped = [re:replace(Word, "[.]", "\\\\&", [{return, list}, global]) || 
+                  Word <- Key],
+    string:join(Escaped, ".").
 
 %% @doc like string:tokens(Key, "."), but if the dot was escaped
 %% i.e. \\., don't tokenize that
@@ -238,4 +250,20 @@ filter_by_variable_starts_with_test() ->
         ],
         FilteredByString),
     ok.
+
+variable_roundtrip_test() ->
+   ?assert(eqc:quickcheck(eqc:testing_time(3, eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
+
+prop_format_tokenize_roundtrip() ->
+    ?FORALL(Variable, non_empty(list(gen_word())),
+            tokenize(format(Variable)) == Variable).
+
+gen_word() ->
+    ?LET(F, non_empty(list(gen_word_char())), lists:flatten(F)).
+
+gen_word_char() ->
+    oneof([$., $_, $-,
+           choose($0, $9),
+           choose($A, $Z),
+           choose($a, $z)]).
 -endif.

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -134,6 +134,8 @@ async_threads_stack_size_test() ->
     TooLarge    = cuttlefish_bytesize:to_string(WordSize * 1024 * 9000),
     Indivisible = cuttlefish_bytesize:to_string(WordSize * 1024 * 16 - 2),
     Correct     = cuttlefish_bytesize:to_string(WordSize * 1024 * 32),
+    MinSize     = cuttlefish_bytesize:to_string(WordSize * 1024 * 16),
+    MaxSize     = cuttlefish_bytesize:to_string(WordSize * 1024 * 8192),
     CorrectRaw = 32,
     
     Conf0 = [],
@@ -146,15 +148,15 @@ async_threads_stack_size_test() ->
 
     Conf2 = [{["erlang", "async_threads", "stack_size"], TooSmall}],
     Config2 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf2, context()),
-    cuttlefish_unit:assert_error_message(Config2, "erlang.async_threads.stack_size invalid, must be in the range of (16..8192) * 1024 * system word-size"),
+    cuttlefish_unit:assert_error_message(Config2, "erlang.async_threads.stack_size invalid, must be in the range of " ++ MinSize ++ " to " ++ MaxSize),
 
     Conf3 = [{["erlang", "async_threads", "stack_size"], TooLarge}],
     Config3 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf3, context()),
-    cuttlefish_unit:assert_error_message(Config3, "erlang.async_threads.stack_size invalid, must be in the range of (16..8192) * 1024 * system word-size"),
+    cuttlefish_unit:assert_error_message(Config3, "erlang.async_threads.stack_size invalid, must be in the range of " ++ MinSize ++ " to " ++ MaxSize),
 
     Conf4 = [{["erlang", "async_threads", "stack_size"], Indivisible}],
     Config4 = cuttlefish_unit:generate_templated_config(["../priv/erlang_vm.schema"], Conf4, context()),
-    cuttlefish_unit:assert_error_message(Config4, "erlang.async_threads.stack_size invalid, must be divisible by the system word-size"),
+    cuttlefish_unit:assert_error_message(Config4, "erlang.async_threads.stack_size invalid, must be divisible by " ++ integer_to_list(WordSize)),
 
     ok.
 


### PR DESCRIPTION
see http://erlang.org/doc/man/erl.html for more details on `+a`.
