### PR TITLE
Address nested-translation errors + refactor

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -111,7 +111,7 @@ generate_element(MappingRecord) ->
     %%    e.g. {include_default, "internal"}
     %%         listener.http.$name -> listener.http.internal
 
-    Field = string:join(cuttlefish_variable:replace_match(Key, IncDef), "."),
+    Field = cuttlefish_variable:format(cuttlefish_variable:replace_match(Key, IncDef)),
 
     case Level of
         basic -> ok;

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -195,7 +195,7 @@ to_string(Value, MaybeExtendedDatatype) ->
 
 -spec from_string(term(), datatype()) -> term() | cuttlefish_error:error().
 from_string(Atom, atom) when is_atom(Atom) -> Atom;
-from_string(String, atom) -> list_to_atom(String);
+from_string(String, atom) when is_list(String) -> list_to_atom(String);
 
 from_string(Value, {enum, Enum}) ->
     cuttlefish_enum:parse(Value, {enum, Enum});
@@ -209,7 +209,7 @@ from_string(String, integer) when is_list(String) ->
     end;
 
 from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
-from_string(String, ip) ->
+from_string(String, ip) when is_list(String) ->
     try begin
         Parts = string:tokens(String, ":"),
         [Port|BackwardsIP] = lists:reverse(Parts),

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -151,11 +151,10 @@ describe(_ParsedArgs, []) ->
     ?STDOUT("cuttlefish's describe command required a variable to query.", []),
     ?STDOUT("Try `describe setting.name`", []),
     stop_deactivate();
-describe(ParsedArgs, Query) when is_list(Query) ->
-    Q = string:join(Query, "."),
-    QDef = string:tokens(Q, "."),
+describe(ParsedArgs, [Query|_]) when is_list(Query) ->
+    QDef = cuttlefish_variable:tokenize(Query),
 
-    lager:debug("cuttlefish describe '~s'", [Q]),
+    lager:debug("cuttlefish describe '~s'", [Query]),
     {_, Mappings, _} = load_schema(ParsedArgs),
 
     FindResults = fun(QueryVar) ->
@@ -168,9 +167,9 @@ describe(ParsedArgs, Query) when is_list(Query) ->
 
     case FindResults(QDef) of
         [] ->
-            ?STDOUT("Variable '~s' not found", [Q]);
+            ?STDOUT("Variable '~s' not found", [Query]);
         [Match|_] ->
-            ?STDOUT("Documentation for ~s", [string:join(cuttlefish_mapping:variable(Match), ".")]),
+            ?STDOUT("Documentation for ~s", [cuttlefish_variable:format(cuttlefish_mapping:variable(Match))]),
             _ = case {cuttlefish_mapping:doc(Match), cuttlefish_mapping:see(Match)} of
                 {[], []} ->
                     ok;
@@ -185,7 +184,7 @@ describe(ParsedArgs, Query) when is_list(Query) ->
                 {Docs, See} ->
                     _ = [ ?STDOUT("~s", [Line]) || Line <- Docs],
                     ?STDOUT("See also:", []),
-                    [?STDOUT("    ~s", [string:join(S, ".")]) || S <- See]
+                    [?STDOUT("    ~s", [cuttlefish_variable:format(S)]) || S <- See]
             end,
             ?STDOUT("", []),
             ValidValues = [
@@ -483,7 +482,7 @@ print_schema(Schema) ->
                 true -> CandidateMax;
                 _ -> OldMax
             end,
-            {NewMax, [{cuttlefish_mapping:mapping(M), string:join(cuttlefish_mapping:variable(M), ".")}|List]}
+            {NewMax, [{cuttlefish_mapping:mapping(M), cuttlefish_variable:format(cuttlefish_mapping:variable(M))}|List]}
         end,
         {0, []},
         Mappings

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -535,7 +535,8 @@ transform_extended_type({DT, AcceptableValue}, Tail, Value, Errors) ->
             transform_type(Tail, Value,
                            [{error, ?FMT("~p is not accepted value: ~p",[Value, AcceptableValue])}
                                      |Errors]);
-        {error, EList} -> EList
+        {error, EList} -> 
+            transform_type(Tail, Value, [{error, EList}|Errors])
     end.
 %% Ok, this is tricky
 %% There are three scenarios we have to deal with:

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -533,17 +533,12 @@ transform_supported_type(DT, Tail, Value, ErrorAcc) ->
                                      {ok, term()} | [cuttlefish_error:error()].
 transform_extended_type({DT, AcceptableValue}, Tail, Value, Errors) ->
     case transform_supported_type(DT, [], Value, Errors) of
-        {ok, NewValue} ->
-            case NewValue =:= AcceptableValue of
-                true -> {ok, NewValue};
-                _ -> transform_type(Tail, Value,
-                                    [{error,
-                                      ?FMT("~p is not accepted value: ~p",
-                                           [Value, AcceptableValue])}
-                                     |Errors])
-            end;
-        {error, EList} ->
-            EList
+        {ok, AcceptableValue} -> {ok, AcceptableValue};
+        {ok, _NewValue} ->
+            transform_type(Tail, Value,
+                           [{error, ?FMT("~p is not accepted value: ~p",[Value, AcceptableValue])}
+                                     |Errors]);
+        {error, EList} -> EList
     end.
 %% Ok, this is tricky
 %% There are three scenarios we have to deal with:

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -35,15 +35,15 @@
 
 -export([map/2, find_mapping/2, add_defaults/2]).
 
--spec map(
-        cuttlefish_schema:schema(),
-        cuttlefish_conf:conf()) ->
-             [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec map(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                 [proplists:property()] |
+                 {error, atom(), cuttlefish_error:errorlist()}.
 map(Schema, Config) ->
     map_add_defaults(Schema, Config).
 
--spec map_add_defaults(cuttlefish_schema:schema(), cuttlefish_conf:conf())
-    -> [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec map_add_defaults(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                              [proplists:property()] |
+                              {error, atom(), cuttlefish_error:errorlist()}.
 map_add_defaults({_, Mappings, _} = Schema, Config) ->
     %% Config at this point is just what's in the .conf file.
     %% add_defaults/2 rolls the default values in from the schema
@@ -56,8 +56,9 @@ map_add_defaults({_, Mappings, _} = Schema, Config) ->
             map_value_sub(Schema, DConfig)
     end.
 
--spec map_value_sub(cuttlefish_schema:schema(), cuttlefish_conf:conf())
-    -> [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec map_value_sub(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                           [proplists:property()] |
+                           {error, atom(), cuttlefish_error:errorlist()}.
 map_value_sub(Schema, Config) ->
     lager:debug("Right Hand Side Substitutions"),
      case value_sub(Config) of
@@ -67,8 +68,9 @@ map_value_sub(Schema, Config) ->
             {error, rhs_subs, {error, EList}}
     end.
 
--spec map_transform_datatypes(cuttlefish_schema:schema(), cuttlefish_conf:conf())
-    -> [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec map_transform_datatypes(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                                     [proplists:property()] |
+                                     {error, atom(), cuttlefish_error:errorlist()}.
 map_transform_datatypes({_, Mappings, _} = Schema, DConfig) ->
     %% Everything in DConfig is of datatype "string",
     %% transform_datatypes turns them into other erlang terms
@@ -81,8 +83,9 @@ map_transform_datatypes({_, Mappings, _} = Schema, DConfig) ->
             {error, transform_datatypes, {error, EList}}
     end.
 
--spec map_validate(cuttlefish_schema:schema(), cuttlefish_conf:conf())
-    -> [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec map_validate(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                          [proplists:property()] |
+                          {error, atom(), cuttlefish_error:errorlist()}.
 map_validate(Schema, Conf) ->
     %% Any more advanced validators
     lager:debug("Validation"),
@@ -94,8 +97,8 @@ map_validate(Schema, Conf) ->
             apply_translations(Schema, Conf, DirectMappings, TranslationsToDrop)
     end.
 
--spec apply_mappings(cuttlefish_schema:schema(), cuttlefish_conf:conf())
-    -> {[proplists:property()], [string()]}.
+-spec apply_mappings(cuttlefish_schema:schema(), cuttlefish_conf:conf()) ->
+                            {[proplists:property()], [string()]}.
 apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     %% This fold handles 1:1 mappings, that have no cooresponding translations
     %% The accumlator is the app.config proplist that we start building from
@@ -135,11 +138,9 @@ apply_mappings({Translations, Mappings, _Validators}, Conf) ->
     TranslationsToDrop = TranslationsToMaybeDrop -- TranslationsToKeep,
     {DirectMappings, TranslationsToDrop}.
 
--spec apply_translations(
-    cuttlefish_schema:schema(),
-    cuttlefish_conf:conf(),
-    [proplists:property()],
-    [string()]) -> [proplists:property()] | {error, atom(), cuttlefish_error:errorlist()}.
+-spec apply_translations(cuttlefish_schema:schema(), cuttlefish_conf:conf(), [proplists:property()], [string()]) ->
+                                [proplists:property()] |
+                                {error, atom(), cuttlefish_error:errorlist()}.
 apply_translations({Translations, _, _} = Schema, Conf, DirectMappings, TranslationsToDrop) ->
     %% The fold handles the translations. After we've build the DirectMappings,
     %% we use that to seed this fold's accumulator. As we go through each translation
@@ -215,8 +216,8 @@ try_apply_translation(Mapping, XlatFun, XlatArgs) ->
         %% Any unknown error, perhaps caused by stdlib
         %% stuff.
         E:R ->
-            {error, ?FMT("Error running translation for ~s, "
-                         "[~p, ~p].", [Mapping, E, R])}
+            {error, ?FMT("Error running translation for ~s, [~p, ~p].",
+                         [Mapping, E, R])}
     end.
 
 %for each token, is it special?

--- a/src/cuttlefish_generator.erl
+++ b/src/cuttlefish_generator.erl
@@ -516,13 +516,6 @@ transform_supported_type(DT, Tail, Value, ErrorAcc) ->
     case {DT, cuttlefish_datatypes:from_string(Value, DT)} of
         {_, {error, Message}} ->
             transform_type(Tail, Value, [{error, Message}|ErrorAcc]);
-        {{enum, PossibleValues}, NewValue} ->
-            case lists:member(NewValue, PossibleValues) of
-                true -> {ok, NewValue};
-                false ->
-                    transform_type(Tail, Value, [
-                        {error, ?FMT("Bad value for enum: ~s", [Value])}|ErrorAcc])
-            end;
         {_, NewValue} -> {ok, NewValue}
     end.
 

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -27,6 +27,7 @@
 -ifdef(TEST).
 -ifdef(EQC).
 -include_lib("eqc/include/eqc.hrl").
+-define(QC_OUT(Prop), on_output(fun(F,A) -> io:format(user, F, A) end, Prop)).
 -endif.
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
@@ -251,8 +252,9 @@ filter_by_variable_starts_with_test() ->
         FilteredByString),
     ok.
 
-variable_roundtrip_test() ->
-   ?assert(eqc:quickcheck(eqc:testing_time(3,eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
+variable_roundtrip_test_() ->
+   {timeout, 15, 
+    [?_assert(quickcheck(testing_time(3,?QC_OUT(prop_format_tokenize_roundtrip()))))]}.
 
 prop_format_tokenize_roundtrip() ->
     ?FORALL(Variable, non_empty(list(gen_word())),

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -255,7 +255,7 @@ filter_by_variable_starts_with_test() ->
 -ifdef(EQC).
 variable_roundtrip_test_() ->
    {timeout, 15, 
-    [?_assert(quickcheck(testing_time(3,?QC_OUT(prop_format_tokenize_roundtrip()))))]}.
+    [?_assert(quickcheck(eqc:testing_time(3,?QC_OUT(prop_format_tokenize_roundtrip()))))]}.
 
 prop_format_tokenize_roundtrip() ->
     ?FORALL(Variable, non_empty(list(gen_word())),

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -252,7 +252,7 @@ filter_by_variable_starts_with_test() ->
     ok.
 
 variable_roundtrip_test() ->
-   ?assert(eqc:quickcheck(eqc:numtests(200,eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
+   ?assert(eqc:quickcheck(eqc:testing_time(3,eqc:on_output(fun(F,A) -> io:format(user, F, A) end, prop_format_tokenize_roundtrip())))).
 
 prop_format_tokenize_roundtrip() ->
     ?FORALL(Variable, non_empty(list(gen_word())),

--- a/src/cuttlefish_variable.erl
+++ b/src/cuttlefish_variable.erl
@@ -252,6 +252,7 @@ filter_by_variable_starts_with_test() ->
         FilteredByString),
     ok.
 
+-ifdef(EQC).
 variable_roundtrip_test_() ->
    {timeout, 15, 
     [?_assert(quickcheck(testing_time(3,?QC_OUT(prop_format_tokenize_roundtrip()))))]}.
@@ -268,4 +269,5 @@ gen_word_char() ->
            choose($0, $9),
            choose($A, $Z),
            choose($a, $z)]).
+-endif.
 -endif.

--- a/test/cuttlefish_nested_schema_test.erl
+++ b/test/cuttlefish_nested_schema_test.erl
@@ -5,15 +5,15 @@
 
 nested_schema_test() ->
     Conf = [
-        {["thing", "a"], on},
+        {["thing", "a"], foo},
         {["nested", "thing1", "type"], "thing"},
-        {["nested", "thing1", "thing", "a"], off},
+        {["nested", "thing1", "thing", "a"], 0},
         {["nested", "thing2", "type"], "thing"}
     ],
     Config = cuttlefish_generator:map(schema(), Conf),
     ?assertEqual(
-        [{thing, [{a, true}]},
-         {nested_things, [{thing, [{a, false}]}, {thing, [{a, true}]}]}],
+        [{thing, [{a, foo}]},
+         {nested_things, [{thing, [{a, 0}]}, {thing, [{a, 5}]}]}],
          Config
         ),
     ok.
@@ -21,15 +21,15 @@ nested_schema_test() ->
 schema() ->
     Mappings = [
         {mapping, "thing.a", "thing.a", [
-            {datatype, flag},
-            {default, on}
+            {datatype, [{atom, foo}, integer]},
+            {default, 5}
         ]},
         {mapping, "nested.$name.type", "nested_things", [
             {datatype, {enum, [thing]}}
         ]},
         {mapping, "nested.$name.thing.a", "nested_things", [
-            {datatype, flag},
-            {default, on}
+            {datatype, [{atom, foo}, integer]},
+            {default, 5}
         ]}
     ],
     Translations = [


### PR DESCRIPTION
In an effort to discover the nested errors that can/do occur in [Riak's schemas](https://github.com/basho/riak/issues/590), this substantially refactors the code in `cuttlefish_generator`.

**This PR targets `develop` but should also be backported/merged to `2.0` branch for the next patch release.**

One source of the problem (as shown in the backtrace in basho/riak#590) was that "extended" datatypes that failed to parse halted all attempts to parse other datatypes in the list. This meant that when calling `cuttlefish_generator:map/2`, if something was already coerced to a valid datatype, it might fail to parse as the extended type and result in the nested configuration failing.

The main refactors are:
- 16a34ed : Broke `cuttlefish_generator:apply_translations()` up into smaller, more digestible functions with fewer responsibilities.
- 71f063c : Caught exceptions resulting from parsing standard datatypes such that they will not completely abort the process.
- cc78e53 : Added more guards to `cuttlefish_datatypes:from_string()` and `to_string()` that caused things like `list_to_atom(36000)` (as in the example in basho/riak#590).
- 039ca0a : Refactored `cuttlefish_generator:transform_type()` so that the functions it calls are not mutually recursive. The control flow was extracted out into a monadic combinator `foldm_either`, while the nested calls simply return `{ok, Value}` or `{error, Reason}`.
- df4c280 : Replaced all manual formatting of varialbes now that `cuttlefish_variable:format/1` exists. Found and fixed a resulting bug in `cuttlefish_escript:describe/2`.
