### PR TITLE
Update rebar.config for OTP 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 


### PR DESCRIPTION
OTP HEAD now announces itself as release 18.
