### PR TITLE
Rework error handling to turn errors into smarter nested tuples

### DIFF
--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -51,7 +51,7 @@ key <- head:word tail:("." word)* %{
 value <- (!((ws* crlf) / comment) .)+ %{
     case unicode:characters_to_binary(Node, utf8, latin1) of
         {_Status, _Begining, _Rest} ->
-            {error, ?FMT("Error converting value on line #~p to latin1", [line(Idx)])};
+            {error, {conf_to_latin1, line(Idx)}};
         Bin ->
             binary_to_list(Bin)
     end
@@ -159,7 +159,7 @@ file_test() ->
 utf8_test() ->
     Conf = conf_parse:parse("setting = thingŒ\n"),
     ?assertEqual([{["setting"],
-            {error, "Error converting value on line #1 to latin1"}
+            {error, {conf_to_latin1, 1}}
         }], Conf),
     ok.
 -endif.

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -205,7 +205,7 @@ from_string(String, integer) when is_list(String) ->
     try list_to_integer(String) of
         X -> X
     catch
-        _:_ -> {error, {conversion, {String, "integer"}}}
+        _:_ -> {error, {conversion, {String, integer}}}
     end;
 
 from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
@@ -217,7 +217,7 @@ from_string(String, ip) when is_list(String) ->
     end of
         X -> X
     catch
-        _:_ -> {error, {conversion, {String, "IP"}}}
+        _:_ -> {error, {conversion, {String, 'IP'}}}
     end;
 
 from_string(Duration, {duration, _}) when is_integer(Duration) -> Duration;
@@ -261,7 +261,7 @@ from_string(String, float) when is_list(String) ->
     try list_to_float(String) of
         X -> X
     catch
-        _:_ -> {error, {conversion, {String, "float"}}}
+        _:_ -> {error, {conversion, {String, float}}}
     end;
 
 from_string(Thing, InvalidDatatype) ->

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -190,7 +190,7 @@ to_string(Value, MaybeExtendedDatatype) ->
         true ->
             to_string(Value, extended_from(MaybeExtendedDatatype));
         _ ->
-            {error, lists:flatten(io_lib:format("Tried to convert ~p, an invalid datatype ~p to_string.", [Value, MaybeExtendedDatatype]))}
+            {error, {type, {Value, MaybeExtendedDatatype}}}
     end.
 
 -spec from_string(term(), datatype()) -> term() | cuttlefish_error:error().
@@ -205,7 +205,7 @@ from_string(String, integer) when is_list(String) ->
     try list_to_integer(String) of
         X -> X
     catch
-        _:_ -> {error, lists:flatten(io_lib:format("~p can't be converted to an integer", [String]))}
+        _:_ -> {error, {conversion, {String, "integer"}}}
     end;
 
 from_string({IP, Port}, ip) when is_list(IP), is_integer(Port) -> {IP, Port};
@@ -217,7 +217,7 @@ from_string(String, ip) when is_list(String) ->
     end of
         X -> X
     catch
-        _:_ -> {error, lists:flatten(io_lib:format("~p cannot be converted into an IP", [String]))}
+        _:_ -> {error, {conversion, {String, "IP"}}}
     end;
 
 from_string(Duration, {duration, _}) when is_integer(Duration) -> Duration;
@@ -240,7 +240,7 @@ from_string(Flag, {flag, _, _}=Type) when is_atom(Flag) -> cuttlefish_flag:parse
 
 from_string(Percent, {percent, integer}) when is_integer(Percent), Percent >= 0, Percent =< 100 -> Percent;
 from_string(Percent, {percent, integer}) when is_integer(Percent) ->
-    {error, lists:flatten(io_lib:format("~p% can't be outside the range 0 - 100%", [Percent]))};
+    {error, {range, {{Percent, {percent, integer}}, "0 - 100%"}}};
 %% This clause ends with a percent sign!
 from_string(Percent, {percent, integer}) when is_list(Percent) ->
     from_string(
@@ -249,7 +249,7 @@ from_string(Percent, {percent, integer}) when is_list(Percent) ->
 
 from_string(Percent, {percent, float}) when is_float(Percent), Percent >= 0, Percent =< 1 -> Percent;
 from_string(Percent, {percent, float}) when is_float(Percent) ->
-    {error, lists:flatten(io_lib:format("~s can't be outside the range 0 - 100%", [to_string(Percent, {percent, float})]))};
+    {error, {range, {{Percent, {percent, float}}, "0 - 100%"}}};
 %% This clause ends with a percent sign!
 from_string(Percent, {percent, float}) when is_list(Percent) ->
     from_string(
@@ -261,13 +261,15 @@ from_string(String, float) when is_list(String) ->
     try list_to_float(String) of
         X -> X
     catch
-        _:_ -> {error, lists:flatten(io_lib:format("~p can't be converted to a float", [String]))}
+        _:_ -> {error, {conversion, {String, "float"}}}
     end;
 
 from_string(Thing, InvalidDatatype) ->
-   {error, lists:flatten(io_lib:format("Tried to convert ~p, an invalid datatype ~p from_string.", [Thing, InvalidDatatype]))}.
+   {error, {type, {Thing, InvalidDatatype}}}.
 
 -ifdef(TEST).
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
 
 to_string_atom_test() ->
     ?assertEqual("split_the", to_string(split_the, atom)),
@@ -332,7 +334,7 @@ to_string_extended_type_test() ->
     ok.
 
 to_string_unsupported_datatype_test() ->
-    ?assertEqual({error, "Tried to convert \"Something\", an invalid datatype unsupported_datatype to_string."}, to_string("Something", unsupported_datatype)).
+    ?assertEqual("Tried to convert \"Something\" but invalid datatype: unsupported_datatype", ?XLATE(to_string("Something", unsupported_datatype))).
 
 from_string_atom_test() ->
     ?assertEqual(split_the, from_string(split_the, atom)),
@@ -341,7 +343,7 @@ from_string_atom_test() ->
 from_string_integer_test() ->
     ?assertEqual(32, from_string(32, integer)),
     ?assertEqual(32, from_string("32", integer)),
-    ?assertEqual({error, "\"thirty_two\" can't be converted to an integer"}, from_string("thirty_two", integer)),
+    ?assertEqual("\"thirty_two\" cannot be converted to a(n) integer", ?XLATE(from_string("thirty_two", integer))),
     ok.
 
 from_string_ip_test() ->
@@ -351,13 +353,13 @@ from_string_ip_test() ->
         from_string("2001:0db8:85a3:0042:1000:8a2e:0370:7334:8098", ip)),
 
     ?assertEqual(
-        {error, "\"This is not an IP\" cannot be converted into an IP"},
-        from_string("This is not an IP", ip)
+       "\"This is not an IP\" cannot be converted to a(n) IP",
+       ?XLATE(from_string("This is not an IP", ip))
         ),
     ok.
 
 from_string_enum_test() ->
-    ?assertEqual({error, "\"a\" is not a valid enum value, acceptable values are [\"b\",\"c\"]."}, from_string(a, {enum, [b, c]})),
+    ?assertEqual("\"a\" is not a valid enum value, acceptable values are: b, c", ?XLATE(from_string(a, {enum, [b, c]}))),
     ?assertEqual(true, from_string("true", {enum, [true, false]})),
     ?assertEqual(true, from_string(true, {enum, [true, false]})).
 
@@ -380,8 +382,8 @@ from_string_percent_integer_test() ->
     %% Range!
     ?assertEqual(0, from_string("0%", {percent, integer})),
     ?assertEqual(100, from_string("100%", {percent, integer})),
-    ?assertEqual({error, "110% can't be outside the range 0 - 100%"}, from_string("110%", {percent, integer})),
-    ?assertEqual({error, "-1% can't be outside the range 0 - 100%"}, from_string("-1%", {percent, integer})),
+    ?assertEqual("110% can't be outside the range 0 - 100%", ?XLATE(from_string("110%", {percent, integer}))),
+    ?assertEqual("-1% can't be outside the range 0 - 100%", ?XLATE(from_string("-1%", {percent, integer}))),
     ok.
 
 from_string_percent_float_test() ->
@@ -390,8 +392,8 @@ from_string_percent_float_test() ->
     %% Range!
     ?assertEqual(0.0, from_string("0%", {percent, float})),
     ?assertEqual(1.0, from_string("100%", {percent, float})),
-    ?assertEqual({error, "110% can't be outside the range 0 - 100%"}, from_string("110%", {percent, float})),
-    ?assertEqual({error, "-1% can't be outside the range 0 - 100%"}, from_string("-1%", {percent, float})),
+    ?assertEqual("110% can't be outside the range 0 - 100%", ?XLATE(from_string("110%", {percent, float}))),
+    ?assertEqual("-1% can't be outside the range 0 - 100%", ?XLATE(from_string("-1%", {percent, float}))),
     ok.
 
 from_string_float_test() ->
@@ -403,7 +405,7 @@ from_string_string_test() ->
     ?assertEqual("string", from_string("string", string)).
 
 from_string_unsupported_datatype_test() ->
-    ?assertEqual({error, "Tried to convert \"string\", an invalid datatype unsupported_datatype from_string."}, from_string("string", unsupported_datatype)).
+    ?assertEqual("Tried to convert \"string\" but invalid datatype: unsupported_datatype", ?XLATE(from_string("string", unsupported_datatype))).
 
 is_supported_test() ->
     ?assert(is_supported(integer)),

--- a/src/cuttlefish_duration.erl
+++ b/src/cuttlefish_duration.erl
@@ -76,7 +76,7 @@ parse(InputDurationString) ->
         Int when is_integer(Int) ->
             Int;
         _ ->
-            {error, ?FMT("Invalid duration value: ~s", [InputDurationString])}
+            {error, {duration, InputDurationString}}
     end.
 
 -ifdef(TEST).

--- a/src/cuttlefish_error.erl
+++ b/src/cuttlefish_error.erl
@@ -21,8 +21,8 @@
 %% -------------------------------------------------------------------
 -module(cuttlefish_error).
 
--type error() :: {error, string()|[string()]}.
--type errorlist() :: {error, [error()]}.
+-type error() :: {'error', {atom(), term()}}.
+-type errorlist() :: {'errorlist', [error()]}.
 -export_type([error/0, errorlist/0]).
 
 -export([
@@ -32,14 +32,121 @@
         errorlist_maybe/1,
         print/1,
         print/2,
-        format/1,
-        format/2
+        xlate/1
 ]).
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
 -endif.
+
+%% We'll be calling this a lot from `xlate'
+-define(STR(X, Y), xlate(cuttlefish_datatypes:to_string(X, Y))).
+
+-spec xlate({atom(), term()}|string()) -> iolist().
+xlate(Message) when is_list(Message) ->
+    %% We allow for strings so that we can safely call
+    %% `cuttlefish_datatypes:to_string` when creating these messages
+    Message;
+xlate({error, Details}) ->
+    xlate(Details);
+xlate({_Error, {error, NestedError}}) ->
+    xlate(NestedError);
+xlate({type, {Value, Type}}) ->
+    io_lib:format("Tried to convert ~p but invalid datatype: ~p",
+                  [Value, Type]);
+xlate({range, {{Value, Type}, Range}}) ->
+    [?STR(Value, Type), " can't be outside the range ", Range];
+xlate({conversion, {Value, Type}}) ->
+    io_lib:format("~p cannot be converted to a(n) ~s", [Value, Type]);
+xlate({duration, Value}) ->
+    io_lib:format("Invalid duration value: ~ts", [Value]);
+xlate({enum_name, {Value, EnumNames}}) ->
+    io_lib:format("~p is not a valid enum value, acceptable values are: ~ts",
+                  [Value, string:join(EnumNames, ", ")]);
+xlate({enum_format, Value}) ->
+    %% This collapses two different type of formatting errors into one
+    %% error message
+    io_lib:format("Enum elements must be atoms, strings, or 2-tuples with "
+                  "atom or string as first element. Bad value: ~w", [Value]);
+xlate({mapping_types, List}) ->
+    io_lib:format("Invalid datatype list for mapping: ~ts",
+                  [string:join(List, ", ")]);
+xlate({mapping_parse, Term}) ->
+    io_lib:format(
+        "Poorly formatted input to cuttlefish_mapping:parse/1 : ~p",
+        [Term]
+     );
+xlate({translation_parse, Term}) ->
+    io_lib:format(
+      "Poorly formatted input to cuttlefish_translation:parse/1 : ~p",
+      [Term]
+     );
+xlate({validator_parse, Term}) ->
+    io_lib:format(
+      "Poorly formatted input to cuttlefish_validator:parse/1 : ~p",
+      [Term]
+     );
+xlate({conf_to_latin1, LineNum}) ->
+    io_lib:format("Error converting value on line #~p to latin1", [LineNum]);
+xlate({bytesize_parse, Value}) ->
+    io_lib:format("Error converting value ~p to a number of bytes", [Value]);
+xlate({file_open, {File, Reason}}) ->
+    io_lib:format("Could not open file (~s) for Reason ~s", [File, Reason]);
+xlate({conf_syntax, {File, {Line, Col}}}) ->
+    io_lib:format("Syntax error in ~s after line ~p column ~p, "
+                  "parsing incomplete", [File, Line, Col]);
+xlate({in_file, {File, Error}}) ->
+    [File, ": ", xlate(Error)];
+xlate({translation_missing_setting, {Translation, Setting}}) ->
+    io_lib:format("Translation for '~s' expected to find setting '~s' but was missing",
+                  [Translation, Setting]);
+xlate({translation_invalid_configuration, {Translation, Invalid}}) ->
+    io_lib:format("Translation for '~s' found invalid configuration: ~s",
+                  [Translation, Invalid]);
+xlate({translation_unknown_error, {Translation, {Class, Error}}}) ->
+    io_lib:format("Error running translation for ~s, [~p, ~p]",
+                  [Translation, Class, Error]);
+xlate({translation_arity, {Translation, Arity}}) ->
+    io_lib:format("~p is not a valid arity for translation fun() ~s."
+                  " Try 1 or 2", [Arity, Translation]);
+xlate({map_multiple_match, VariableDefinition}) ->
+    io_lib:format("~p has both a fuzzy and strict match", [VariableDefinition]);
+xlate({unknown_variable, Variable}) ->
+    ["Conf file attempted to set unknown variable: ", Variable];
+xlate({unsupported_type, Type}) ->
+    io_lib:format("~p is not a supported datatype", [Type]);
+xlate({transform_type, Type}) ->
+    ["Error transforming datatype for: ", Type];
+xlate({transform_type_exception, {Type, {Class, Error}}}) ->
+    io_lib:format("Caught exception converting to ~p: ~p:~p",
+                  [Type, Class, Error]);
+xlate({transform_type_unacceptable, {Value, BadValue}}) ->
+    io_lib:format("~p is not accepted value: ~p", [Value, BadValue]);
+xlate({circular_rhs, History}) ->
+    io_lib:format("Circular RHS substitutions: ~p", [History]);
+xlate({substitution_missing_config, {Substitution, Variable}}) ->
+    io_lib:format("'~s' substitution requires a config variable '~s' to be set",
+                  [Substitution, Variable]);
+xlate({mapping_not_found, Variable}) ->
+    [Variable, " not_found"];
+xlate({mapping_multiple, {Variable, {Hard, Fuzzy}}}) ->
+    io_lib:format("~p hard mappings and ~p fuzzy mappings found "
+                  "for ~s", [Hard, Fuzzy, Variable]);
+xlate({validation, {Variable, Description}}) ->
+    [Variable, " invalid, ", Description];
+xlate({erl_parse, {Reason, LineNo}}) ->
+    ["Schema parse error near line number ", integer_to_list(LineNo),
+     ": ", Reason];
+xlate({erl_parse, Reason}) ->
+    io_lib:format("Schema parse error: ~p", [Reason]);
+xlate({erl_parse_unexpected, Error}) ->
+    io_lib:format("Unexpected return from erl_parse:parse_exprs/1: ~p",
+                  [Error]);
+xlate({parse_schema, Value}) ->
+    io_lib:format("Unknown parse return: ~p", [Value]);
+xlate({erl_scan, LineNo}) ->
+    ["Error scanning erlang near line ", integer_to_list(LineNo)].
 
 -spec contains_error(list()) -> boolean().
 contains_error(List) ->
@@ -51,12 +158,12 @@ is_error(_) -> false.
 
 -spec filter(list()) -> errorlist().
 filter(List) ->
-    {error, lists:filter(fun is_error/1, List)}.
+    {errorlist, lists:filter(fun is_error/1, List)}.
 
 -spec errorlist_maybe(any()) -> any().
 errorlist_maybe(List) when is_list(List) ->
     case filter(List) of
-        {error, []} ->
+        {errorlist, []} ->
             List;
         Errorlist ->
             Errorlist
@@ -68,8 +175,8 @@ print(FormatString, Args) ->
     print(io_lib:format(FormatString, Args)).
 
 -spec print(string() | error()) -> ok.
-print({error, List}) ->
-    print(lists:flatten(List));
+print({error, ErrorTerm}) ->
+    print(lists:flatten(xlate(ErrorTerm)));
 print(String) ->
     case lager:error("~s", [String]) of
         {error, lager_not_running} ->
@@ -77,13 +184,6 @@ print(String) ->
             ok;
         ok -> ok
     end.
-
--spec format(io:format()) -> error().
-format(Str) -> format(Str, []).
-
--spec format(io:format(), list()) -> error().
-format(Str, List) ->
-    {error, lists:flatten(io_lib:format(Str, List))}.
 
 -ifdef(TEST).
 
@@ -98,8 +198,8 @@ contains_error_test() ->
     ok.
 
 filter_test() ->
-    ?assertEqual({error, []}, filter(["hi", "what even is an error?", "bye"])),
-    ?assertEqual({error, [{error, "etoomanythings"}]},
+    ?assertEqual({errorlist, []}, filter(["hi", "what even is an error?", "bye"])),
+    ?assertEqual({errorlist, [{error, "etoomanythings"}]},
                  filter(["hi", {error, "etoomanythings"}, "bye"])),
     ok.
 
@@ -110,16 +210,11 @@ errorlist_maybe_test() ->
     ?assertEqual("string", errorlist_maybe("string")),
 
     ?assertEqual(
-       {error, [{error, "etoomanythings"}]},
+       {errorlist, [{error, "etoomanythings"}]},
        errorlist_maybe(["hi", {error, "etoomanythings"}, "bye"])),
     ?assertEqual(
        ["hi", "what even is an error?", "bye"],
        errorlist_maybe(["hi", "what even is an error?", "bye"])),
-    ok.
-
-format_test() ->
-    ?assertEqual({error, "Hi!"}, format("Hi!")),
-    ?assertEqual({error, "Error: 17"}, format("Error: ~p", [17])),
     ok.
 
 -endif.

--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -304,10 +304,11 @@ load_conf(ParsedArgs) ->
     ConfFiles = proplists:get_all_values(conf_file, ParsedArgs),
     lager:debug("ConfFiles: ~p", [ConfFiles]),
     case cuttlefish_conf:files(ConfFiles) of
-        {error, Errors} ->
-            _ = [ lager:error(E) || {error, E} <- Errors],
+        {errorlist, Errors} ->
+            _ = [ lager:error(cuttlefish_error:xlate(E)) ||
+                    {error, E} <- Errors],
             stop_deactivate(),
-            {error, Errors};
+            {errorlist, Errors};
         GoodConf ->
             GoodConf
     end.
@@ -358,7 +359,7 @@ engage_cuttlefish(ParsedArgs) ->
 
     Conf = load_conf(ParsedArgs),
     NewConfig = case cuttlefish_generator:map(Schema, Conf) of
-        {error, Phase, {error, Errors}} ->
+        {error, Phase, {errorlist, Errors}} ->
             lager:error("Error generating configuration in phase ~s", [Phase]),
             _ = [ cuttlefish_error:print(E) || E <- Errors],
             stop_deactivate();

--- a/src/cuttlefish_rebar_plugin.erl
+++ b/src/cuttlefish_rebar_plugin.erl
@@ -51,7 +51,7 @@ generate(Config0, ReltoolFile) ->
                     io:format("Schema: ~p~n", [Schemas]),
 
                     case cuttlefish_schema:files(Schemas) of
-                        {error, _Es} ->
+                        {errorlist, _Es} ->
                             %% These errors were already printed
                             error;
                         {_Translations, Mappings, _Validators} ->

--- a/src/cuttlefish_translation.erl
+++ b/src/cuttlefish_translation.erl
@@ -43,7 +43,7 @@
     func/1,
     replace/2]).
 
--spec parse(raw_translation()) -> translation() | {error, list()}.
+-spec parse(raw_translation()) -> translation() | cuttlefish_error:error().
 parse({translation, Mapping}) ->
     #translation{
         mapping = Mapping
@@ -54,11 +54,7 @@ parse({translation, Mapping, Fun}) ->
         func = Fun
     };
 parse(X) ->
-    {error,
-     io_lib:format(
-        "poorly formatted input to cuttlefish_translation:parse/1 : ~p",
-        [X]
-    )}.
+    {error, {translation_parse, X}}.
 
 %% This assumes it's run as part of a foldl over new schema elements
 %% in which case, there's only ever one instance of a key in the list
@@ -96,6 +92,8 @@ replace(Translation, ListOfTranslations) ->
     end.
 
 -ifdef(TEST).
+
+-define(XLATE(X), lists:flatten(cuttlefish_error:xlate(X))).
 
 parse_test() ->
     TranslationDataStruct = {
@@ -173,11 +171,11 @@ parse_and_merge_test() ->
     ok.
 
 parse_error_test() ->
-    {ErrorAtom, IOList} = parse(not_a_raw_translation),
+    {ErrorAtom, ErrorTuple} = parse(not_a_raw_translation),
     ?assertEqual(error, ErrorAtom),
     ?assertEqual(
-        "poorly formatted input to cuttlefish_translation:parse/1 : not_a_raw_translation",
-        lists:flatten(IOList)),
+        "Poorly formatted input to cuttlefish_translation:parse/1 : not_a_raw_translation",
+        ?XLATE(ErrorTuple)),
     ok.
 
 parse_empty_test() ->

--- a/src/cuttlefish_unit.erl
+++ b/src/cuttlefish_unit.erl
@@ -56,10 +56,10 @@ assert_valid_config(Config) ->
     case Config of
         List when is_list(List) ->
             ok;
-        {error, Phase, {error, Errors}} ->
+        {error, Phase, {errorlist, Errors}} ->
             erlang:exit({assert_valid_config_failed,
                          [{phase, Phase},
-                          {error, Errors}]});
+                          {errorlist, Errors}]});
         Other ->
             erlang:exit({assert_valid_config_failed,
                          [{bad_value, Other}]})
@@ -93,12 +93,12 @@ assert_not_configured(Config, Path) ->
 
 %% @doc Asserts that the generated configuration is in error.
 assert_error(Config) ->
-    ?assertMatch({error, _, {error, _}}, Config).
+    ?assertMatch({error, _, {errorlist, _}}, Config).
 
 %% @doc Asserts that the generated configuration is in error, with the
 %% error occurring in a specific phase.
 assert_error_in_phase(Config, Phase) when is_atom(Phase) ->
-    ?assertMatch({error, Phase, {error, _}}, Config).
+    ?assertMatch({error, Phase, {errorlist, _}}, Config).
 
 %% @doc Asserts that the generated configuration is in error, and the
 %% given error message was emitted by the given phase.
@@ -119,18 +119,23 @@ assert_errors(Config, Phase, [H|_]=Messages) when is_list(H) ->
     [ assert_error_message(Config, Message) || Message <- Messages ].
 
 %% @doc Asserts that the generated configuration is in error and
-%% contains the given error message.
+%% contains an error tuple that translates to the given error message
 assert_error_message(Config, Message) ->
     ok = assert_error(Config),
-    {error, Messages} = element(3, Config),
-    case lists:member({error, Message}, Messages) of
-        true -> ok;
-        false ->
-            erlang:exit({assert_error_message_failed,
-                         [{expected, Message},
-                          {actual, Messages}]})
-    end.
+    {errorlist, Errors} = element(3, Config),
+    chase_message(Message, Errors, Errors).
 
+chase_message(Message, [], Errors) ->
+    erlang:exit({assert_error_message_failed,
+                 [{expected, Message},
+                  {actual, Errors}]});
+chase_message(Message, [{error, ErrorTerm}|T], Errors) ->
+    case lists:flatten(cuttlefish_error:xlate(ErrorTerm)) of
+        Message ->
+            ok;
+        _ ->
+            chase_message(Message, T, Errors)
+    end.
 
 -spec path(cuttlefish_variable:variable(),
            [{ string() | atom() | binary() , term()}]) ->

--- a/src/cuttlefish_util.erl
+++ b/src/cuttlefish_util.erl
@@ -72,8 +72,9 @@ fuzzy_variable_match(Var, VarDef) ->
 replace_proplist_value(Key, Value, Proplist) ->
     lists:keystore(Key, 1, Proplist, {Key, Value}).
 
-%% @doc turn a string into a number in a way I am happy with
--spec numerify(string()) -> integer()|float()|{error, string()}.
+%% @doc Turn a string into a number if `list_to_float' or
+%% `list_to_integer' accept it as valid
+-spec numerify(string()) -> integer()|float()|cuttlefish_error:error().
 numerify([$.|_]=Num) -> numerify([$0|Num]);
 numerify(String) ->
     try list_to_float(String) of
@@ -84,7 +85,7 @@ numerify(String) ->
                 Int -> Int
             catch
                 _:_ ->
-                    {error, String}
+                    {error, {number_parse, String}}
             end
     end.
 


### PR DESCRIPTION
- `{error, "Arbitrary string"}` becomes `{error, {atom(), term()}}`
- `{error, [error()]}` becomes `{errorlist, [error()]}`
- Add `cuttlefish_error:xlate/1` to take new error tuples and convert to (roughly) same strings as before
- Simplify `cuttlefish_bytesize:parse/1`
- General -spec cleanup
## API change
- Remove `cuttlefish_error:format`, used nowhere
