### PR TITLE
Don't create atoms from user input.

### DIFF
--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -195,7 +195,13 @@ to_string(Value, MaybeExtendedDatatype) ->
 
 -spec from_string(term(), datatype()) -> term() | cuttlefish_error:error().
 from_string(Atom, atom) when is_atom(Atom) -> Atom;
-from_string(String, atom) when is_list(String) -> list_to_atom(String);
+from_string(String, atom) when is_list(String) ->
+    try
+        list_to_existing_atom(String)
+    catch
+        error:badarg ->
+            {error, {conversion, {String, atom}}}
+    end;
 
 from_string(Value, {enum, Enum}) ->
     cuttlefish_enum:parse(Value, {enum, Enum});
@@ -338,7 +344,8 @@ to_string_unsupported_datatype_test() ->
 
 from_string_atom_test() ->
     ?assertEqual(split_the, from_string(split_the, atom)),
-    ?assertEqual(split_the, from_string("split_the", atom)).
+    ?assertEqual(split_the, from_string("split_the", atom)),
+    ?assertMatch({error, {conversion, _}}, from_string("unknown_atom_to_explode_table", atom)).
 
 from_string_integer_test() ->
     ?assertEqual(32, from_string(32, integer)),


### PR DESCRIPTION
This is not strictly necessary for basho/clique#45, but would allow removal of some workaround code. I'm not certain of the impact of this on third-party schemas, but will at least scan Riak's schemas.
