### PR TITLE
Don't create log directory and empty crash.log under PWD

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -79,6 +79,7 @@ main(Args) ->
     end,
 
     application:set_env(lager, handlers, [{lager_stderr_backend, LogLevel}]),
+    application:set_env(lager, crash_log, false),
     lager:start(),
     lager:debug("Cuttlefish set to debug level logging"),
 


### PR DESCRIPTION
Executing `cuttlefish` escript creates empty `log/crash.log` file under
working directory.

```
% ls
Makefile  README.md  cuttlefish  deps  ebin  priv  rebar  rebar.config  src  test  test_fixtures  tools.mk
% ./cuttlefish -h
Usage: ./cuttlefish [-h] [-e <etc_dir>] [-d <dest_dir>] [-f <dest_file>] [-s <schema_dir>] [-i <schema_file>] [-c <conf_file>] [-a <app_config>] [-l <log_level>] [-p] [-m <max_history>]
[snip more output]
% ls
Makefile  README.md  cuttlefish  deps  ebin  log  priv  rebar  rebar.config  src  test  test_fixtures  tools.mk
```

Background:

After installing `riak-cs` package and execute `riak-cs start`, there is a
file `/usr/lib/riak-cs/log/crash.log`. It is almost harmless but unconfortable
because `/usr/lib/riak-cs/` is usually considered as read only.
