### PR TITLE
BEAM options of non-smp and no async thread

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.
 
-{escript_emu_args, "%%! -escript main cuttlefish_escript\n"}.
+{escript_emu_args, "%%! -escript main cuttlefish_escript -smp disable +A 0\n"}.
 {escript_incl_apps, [goldrush, getopt, lager]}.
 
 {xref_checks, []}.


### PR DESCRIPTION
No async thread flag reduces execution time considerably and
non-smp flag does a little more.

Bellow is a little measurament on my laptop.
## Develop (commit c92c8325aeaea6b6ba7516bbd434f8e408f87d60)

```
% for i in {1..5}; do time ./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1; done
./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  1.35s user 1.23s system 118% cpu 2.175 total
./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  1.24s user 1.26s system 120% cpu 2.084 total
./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  1.30s user 1.27s system 119% cpu 2.149 total
./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  1.34s user 1.36s system 119% cpu 2.265 total
./cuttlefish-orig -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  1.40s user 1.42s system 121% cpu 2.319 total
```
## `-smp disable +A 0`

```
% for i in {1..5}; do time ./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1; done
./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.42s user 0.07s system 99% cpu 0.493 total
./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.41s user 0.08s system 99% cpu 0.490 total
./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.40s user 0.09s system 99% cpu 0.498 total
./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.45s user 0.07s system 99% cpu 0.525 total
./cuttlefish-non-smp-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.42s user 0.08s system 99% cpu 0.498 total
```
## `+A 0`

```
% for i in {1..5}; do time ./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1; done
./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.49s user 0.11s system 99% cpu 0.600 total
./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.53s user 0.04s system 99% cpu 0.570 total
./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.46s user 0.10s system 99% cpu 0.566 total
./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.48s user 0.09s system 99% cpu 0.572 total
./cuttlefish-A0 -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.47s user 0.09s system 99% cpu 0.567 total
```
## `-smp disable`

```
% for i in {1..5}; do time ./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1; done
./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.82s user 0.75s system 90% cpu 1.745 total
./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.54s user 0.16s system 99% cpu 0.708 total
./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.50s user 0.23s system 99% cpu 0.724 total
./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.54s user 0.15s system 99% cpu 0.694 total
./cuttlefish-non-smp -d tmp -s ../riak-2.0/dev/dev1/lib/ > /dev/null 2>&1  0.53s user 0.18s system 99% cpu 0.719 total
```
