### PR TITLE
Fixed regexp for escriptize to only special case win32.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,6 @@
   ]}.
 
 {post_hooks, [
-    {"win32", compile, "rebar escriptize"},
-    {"((?!win32).)*$", compile, "./rebar escriptize"}
+    {"-win32", compile, "rebar escriptize"},
+    {"^((?!-win32).)*$", compile, "./rebar escriptize"}
   ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 
 {post_hooks, [
     {"win32", compile, "rebar escriptize"},
-    {"(linux|darwin)", compile, "./rebar escriptize"}
+    {"((?!win32).)*$", compile, "./rebar escriptize"}
   ]}.


### PR DESCRIPTION
Thanks Internet http://stackoverflow.com/questions/406230/regular-expression-to-match-text-that-doesnt-contain-a-word

Rather than checking on all platforms I persuaded myself this was reasonable with this

```
1>  Archs = ["darwin","linux","win32", "win32weirdthing"].
["darwin","linux","win32","win32weirdthing"]
2> [{Arch, re:run(Arch, "^((?!win32).)*$", [{capture,none}])} || Arch <- Archs].
[{"darwin",match},
 {"linux",match},
 {"win32",nomatch},
 {"win32weirdthing",nomatch}]
```
