### PR TITLE
Able to build cuttlefish w/Erlang 18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 


### PR DESCRIPTION
I've modified `rebar.config` to be able to build this library with Erlang 18.0.
I've run `make test`, the result of which is almost OK but the test did not pass one test w/Erlang 18.0 and 17.5 as below:
- Erlang 18.0

```
module 'conf_parse'
  conf_parse: file_test...[0.007 s] ok
  conf_parse: utf8_test...*failed*
in function erlang:list_to_binary/1
  called as list_to_binary([115,101,116,116,105,110,103,32,61,32,116,104,105,110|...])
in call from conf_parse:parse/1 (src/conf_parse.erl, line 106)
in call from conf_parse:utf8_test/0 (src/conf_parse.erl, line 95)
**error:badarg
  output:<<"">>
```
- Erlang 17.5

```
module 'conf_parse'
  conf_parse: file_test...[0.008 s] ok
  conf_parse: utf8_test...*failed*
in function erlang:list_to_binary/1
  called as list_to_binary([115,101,116,116,105,110,103,32,61,32,116,104,105,110|...])
in call from conf_parse:parse/1 (src/conf_parse.erl, line 106)
in call from conf_parse:utf8_test/0 (src/conf_parse.erl, line 95)
**error:badarg
```

It would be nice if you check this request.
