### PR TITLE
Update dependencies

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,8 +12,8 @@
 {xref_queries, [{"(XC - UC) || (XU - X - B - \"(rebar.*|mustache)\" : Mod)", []}]}.
 
 {deps, [
-    {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
-    {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
+    {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
+    {lager, "(2.0|2.1).*", {git, "git://github.com/basho/lager.git", {tag, "2.1.1"}}},
     {neotoma, "1.7.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.2"}}}
   ]}.
 


### PR DESCRIPTION
Part of https://github.com/basho/riak_cs/pull/1190 . Cuttlefish should not force lager version too strictly. Which version is better to tag this, as 2.0.4 or 2.1.0 ?
