### PR TITLE
Fix/erlang18

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
-    {lager, "(2.0|2.1).*", {git, "git://github.com/basho/lager.git", {tag, "2.1.1"}}},
+    {lager, "(2.0|2.1|2.2).*", {git, "git://github.com/basho/lager.git", {tag, "2.2.0"}}},
     {neotoma, "1.7.3", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.3"}}}
   ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R16|17"}.
+{require_otp_vsn, "R16|17|18"}.
 
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 


### PR DESCRIPTION
This fixes #196 (RIAK-2055).

Would be nice to get a new neotoma release so we don't have to track master.
