### PR TITLE
Do not rely on file encoding for non-latin1 character in utf8 test

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.8.2"}}},
     {lager, "(2.0|2.1).*", {git, "git://github.com/basho/lager.git", {tag, "2.1.1"}}},
-    {neotoma, "1.7.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.2"}}}
+    {neotoma, "1.7.3", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.3"}}}
   ]}.
 
 {post_hooks, [

--- a/src/conf_parse.peg
+++ b/src/conf_parse.peg
@@ -157,7 +157,7 @@ file_test() ->
     ok.
 
 utf8_test() ->
-    Conf = conf_parse:parse("setting = thingŒ\n"),
+    Conf = conf_parse:parse("setting = thing" ++ [338] ++ "\n"),
     ?assertEqual([{["setting"],
             {error, {conf_to_latin1, 1}}
         }], Conf),


### PR DESCRIPTION
Recent work to incorporate a Unicode-friendly version of neotoma has revealed a minor test issue that results in inconsistencies when testing on R16 vs 17/18. Fix this so we can update our dependencies.

In short, under R16 with the latest tagged neotoma this test fails to generate a unicode error as expected, because the non-latin1 character is split into two integers that fall within the latin1 space.
