### PR TITLE
Fix 'false' to string.

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -146,7 +146,7 @@ generate_comments(M) ->
     Default = case cuttlefish_mapping:default(M) of
                   undefined -> [];
                   Other ->
-                      [ "", ?FMT("Default: ~s", [cuttlefish_datatypes:to_string(Other, DefaultDT)]) ]
+                      [ "", ?FMT("Default: ~p", [cuttlefish_datatypes:to_string(Other, DefaultDT)]) ]
               end,
 
     Datatypes = ["", "Acceptable values:" |

--- a/src/cuttlefish_datatypes.erl
+++ b/src/cuttlefish_datatypes.erl
@@ -160,6 +160,7 @@ to_string(Bytesize, bytesize) when is_list(Bytesize) -> Bytesize;
 to_string(Bytesize, bytesize) when is_integer(Bytesize) -> cuttlefish_bytesize:to_string(Bytesize);
 
 to_string(String, string) when is_list(String) -> String;
+to_string(Atom,   string) when is_atom(Atom) -> atom_to_list(Atom);
 
 to_string(File, file) when is_list(File) -> File;
 


### PR DESCRIPTION
I have encountered a problem when tried to generate default config from riak.schema at:

``` erlang
...
%% VM scheduler collapse, part 2 of 2                                                                                                                                                          
{mapping, "erlang.schedulers.compaction_of_load", "vm_args.+scl", [
  {default, false},
  merge
]}.
...
```
