### PR TITLE
Support optional app.config generation without date suffix

### DIFF
--- a/src/cuttlefish_escript.erl
+++ b/src/cuttlefish_escript.erl
@@ -346,12 +346,10 @@ engage_cuttlefish(ParsedArgs) ->
                   Path -> Path
     end,
 
-    Date = calendar:local_time(),
-
-    DestinationFilename = filename_maker(proplists:get_value(dest_file, ParsedArgs), Date, "config"),
+    DestinationFilename = filename_maker(proplists:get_value(dest_file, ParsedArgs), "config"),
     Destination = filename:join(AbsPath, DestinationFilename),
 
-    DestinationVMArgsFilename = filename_maker("vm", Date, "args"),
+    DestinationVMArgsFilename = filename_maker("vm", "args"),
     DestinationVMArgs = filename:join(AbsPath, DestinationVMArgsFilename),
 
     lager:debug("Generating config in: ~p", [Destination]),
@@ -455,8 +453,15 @@ check_existence(EtcDir, Filename) ->
     lager:info("Checking ~s exists... ~p", [FullName, Exists]),
     {Exists, FullName}.
 
-filename_maker(Filename, Date, Extension) ->
-    {{Y, M, D}, {HH, MM, SS}} = Date,
+filename_maker(Filename, Extension) ->
+    case length(string:tokens(Filename, ".")) of
+        1 -> filename_maker(add_suffix, Filename, Extension);
+        _ -> filename_maker(no_suffix, Filename, Extension)
+    end.
+
+filename_maker(no_suffix, Filename, _Extension) -> Filename;
+filename_maker(add_suffix, Filename, Extension) ->
+    {{Y, M, D}, {HH, MM, SS}} = calendar:local_time(),
     _DestinationFilename =
         io_lib:format("~s.~p.~s.~s.~s.~s.~s.~s",
             [Filename,


### PR DESCRIPTION
Depending on wether the dest_file parameter is a complete
filename with extension, skip or append the datetime suffix
at the end of it.

So for example, `-dest_file component.config` will result in a `component.config` file and  `-dest_file component` will result in a `component.2016.02.07.22.46.49.config` file.
This is useful for generating dependency specific .config files that will the included from the main application `sys.config`file, since the generated name with the timestamp is always different it makes it difficult for this use case.
