### PR TITLE
Properly compare versions with and w/o leading R letter

### DIFF
--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -52,10 +52,10 @@ otp(DesiredMinimumOTPVersion, IfGreaterOrEqual, IfLessThan) ->
 otp([], []) ->
     %% They're the same length AND all previous chars were matches
     true;
-otp([$R|TMin], TVer) ->
-    otp(TMin, TVer);
-otp(TMin, [$R|TVer]) ->
-    otp(TMin, TVer);
+otp([$R|TMin], Ver) ->
+    otp(TMin, Ver);
+otp(Min, [$R|TVer]) ->
+    otp(Min, TVer);
 otp([H|TMin], [H|TVer]) ->
     %% The head chars are equal, test the tails
     otp(TMin, TVer);

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -140,9 +140,10 @@ otp_test() ->
     ?assert(not(otp("R16B01", "R16A"))),
     ?assert(otp("R16A", "R16A")),
     ?assert(otp("R16", "17")),
+    ?assert(otp("R16B03-1", "17")),
     ?assert(not(otp("17", "R16"))),
-    ?assert(otp("R16A", "17.4")),
-    ?assert(not(otp("18.2.4", "17.4"))),
+    ?assert(otp("R16A", "17")),
+    ?assert(not(otp("18", "17"))),
     ok.
 
 -endif.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -52,6 +52,10 @@ otp(DesiredMinimumOTPVersion, IfGreaterOrEqual, IfLessThan) ->
 otp([], []) ->
     %% They're the same length AND all previous chars were matches
     true;
+otp([$R|TMin], TVer) ->
+    otp(TMin, TVer);
+otp(TMin, [$R|TVer]) ->
+    otp(TMin, TVer);
 otp([H|TMin], [H|TVer]) ->
     %% The head chars are equal, test the tails
     otp(TMin, TVer);
@@ -135,6 +139,8 @@ otp_test() ->
     ?assert(otp("R16", "R16A")),
     ?assert(not(otp("R16B01", "R16A"))),
     ?assert(otp("R16A", "R16A")),
+    ?assert(otp("R16A", "17.4")),
+    ?assert(not(otp("18.2.4", "17.4"))),
     ok.
 
 -endif.

--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -139,6 +139,8 @@ otp_test() ->
     ?assert(otp("R16", "R16A")),
     ?assert(not(otp("R16B01", "R16A"))),
     ?assert(otp("R16A", "R16A")),
+    ?assert(otp("R16", "17")),
+    ?assert(not(otp("17", "R16"))),
     ?assert(otp("R16A", "17.4")),
     ?assert(not(otp("18.2.4", "17.4"))),
     ok.

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -28,8 +28,8 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "vm_args.-kernel net_ticktime"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_min"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_max"),
-    case erlang:system_info(otp_release) of
-        [$R, $1, N|_] when N >= $6 ->
+    case cuttlefish:otp("R16", erlang:system_info(otp_release)) of
+        true ->
             cuttlefish_unit:assert_config(Config, "vm_args.+Q", 262144),
             cuttlefish_unit:assert_config(Config, "vm_args.+e", 256000);
         _ ->
@@ -88,8 +88,8 @@ override_schema_test() ->
     %% These settings are version dependent, so we won't even test them here
     %% because we don't know what version you're running, so we'll cover it
     %% in two tests below
-    case erlang:system_info(otp_release) of
-        [$R, $1, N|_] when N >= $6 ->
+    case cuttlefish:otp("R16", erlang:system_info(otp_release)) of
+        true ->
             cuttlefish_unit:assert_config(Config, "vm_args.+Q", 32000),
             cuttlefish_unit:assert_config(Config, "vm_args.+e", 128000);
         _ ->


### PR DESCRIPTION
Compare OTP versions with and w/o leading "R" letter properly.
