### PR TITLE
Add `new_conf_value` attribute

### DIFF
--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -140,12 +140,11 @@ get_default(MappingRecord) ->
     %% default directly) is that `default` also affects default values used for
     %% config keys that haven't been set to any particular value in the .conf file.
     %% (See `cuttlefish_generator:add_defaults` for the relevant bits of code.)
-    Default = cuttlefish_mapping:default(MappingRecord),
-    NewConfValue = cuttlefish_mapping:new_conf_value(MappingRecord),
-
-    case NewConfValue of
-        undefined -> Default;
-        _ -> NewConfValue
+    case cuttlefish_mapping:new_conf_value(MappingRecord) of
+        undefined ->
+            cuttlefish_mapping:default(MappingRecord);
+        Value ->
+            Value
     end.
 
 generate_element(true, _, _, _) -> no;

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -101,7 +101,8 @@ generate_file(Mappings, Filename) ->
 
 -spec generate_element(cuttlefish_mapping:mapping()) -> [string()].
 generate_element(MappingRecord) ->
-    Default = cuttlefish_mapping:default(MappingRecord),
+    Default0 = cuttlefish_mapping:default(MappingRecord),
+    ConfFileDefault = cuttlefish_mapping:config_file_default(MappingRecord),
     Key = cuttlefish_mapping:variable(MappingRecord),
     Commented = cuttlefish_mapping:commented(MappingRecord),
     Level = cuttlefish_mapping:level(MappingRecord),
@@ -121,6 +122,11 @@ generate_element(MappingRecord) ->
         Level ->
             lager:warning("{level, ~p} has been deprecated. Use 'hidden' or '{hidden, true}'", [Level])
     end,
+
+    Default = case ConfFileDefault of
+                  undefined -> Default0;
+                  _ -> ConfFileDefault
+              end,
 
     case generate_element(Hidden, Level, Default, Commented) of
         no ->

--- a/src/cuttlefish_conf.erl
+++ b/src/cuttlefish_conf.erl
@@ -244,6 +244,31 @@ generate_element_test() ->
       ),
     ok.
 
+generate_conf_default_test() ->
+    TestMappings = [{mapping, "default.absent", "undefined",
+                     [{datatype, integer},
+                      {config_file_default, 42}]},
+                     {mapping, "default.present", "undefined",
+                      [{datatype, integer},
+                       {default, -1},
+                       {config_file_default, 9001}]}],
+
+    TestSchema = lists:map(fun cuttlefish_mapping:parse/1, TestMappings),
+    GeneratedConf = generate(TestSchema),
+
+    %% TODO Feels pretty fragile to rely on the number of comment lines not changing...
+    %% Would be nice if we had a good way to pinpoint the line we want to check without
+    %% having to hardcode the line numbers into the lists:nth calls.
+    ?assertEqual(
+       "default.absent = 42",
+       lists:nth(4, GeneratedConf)
+      ),
+    ?assertEqual(
+       "default.present = 9001",
+       lists:nth(11, GeneratedConf)
+      ),
+    ok.
+
 generate_dollar_test() ->
     TestSchemaElement =
         cuttlefish_mapping:parse({ mapping, "listener.http.$name", "riak_core.http", [

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -261,6 +261,7 @@ mapping_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_config_file_val"},
             {doc, ["documentation", "for feature"]},
             {validators, ["valid.the.impailer"]},
             hidden
@@ -276,6 +277,7 @@ mapping_test() ->
     ?assertEqual([{enum, [on, off]}], Record#mapping.datatype),
     ?assertEqual(["documentation", "for feature"], Record#mapping.doc),
     ?assertEqual("default_substitution", Record#mapping.include_default),
+    ?assertEqual("default_config_file_val", Record#mapping.config_file_default),
     ?assertEqual(["valid.the.impailer"], Record#mapping.validators),
     ?assertEqual(true, Record#mapping.hidden),
 
@@ -287,6 +289,7 @@ mapping_test() ->
     ?assertEqual([{enum, [on, off]}], datatype(Record)),
     ?assertEqual(["documentation", "for feature"], doc(Record)),
     ?assertEqual("default_substitution", include_default(Record)),
+    ?assertEqual("default_config_file_val", config_file_default(Record)),
     ?assertEqual(["valid.the.impailer"], validators(Record)),
     ?assertEqual(true, hidden(Record)),
 
@@ -303,6 +306,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_conf_val18"},
             {doc, ["documentation", "for feature"]}
         ]
     }),
@@ -318,6 +322,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_conf_val_A"},
             {doc, ["documentation", "for feature"]}
         ]
     })
@@ -333,6 +338,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_conf_val_B"},
             {doc, ["documentation", "for feature"]}
         ]
     }),
@@ -395,6 +401,7 @@ parse_and_merge_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_conf_val_A"},
             {doc, ["documentation", "for feature"]},
             hidden
         ]
@@ -409,6 +416,7 @@ parse_and_merge_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
+            {config_file_default, "default_conf_val_B"},
             {doc, ["documentation", "for feature"]}
         ]
     })

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -35,6 +35,7 @@
         level = basic :: basic | intermediate | advanced,
         doc = [] :: list(),
         include_default = undefined :: string() | undefined,
+        config_file_default = undefined :: string() | undefined,
         validators = [] :: [string()],
         is_merge = false :: boolean(),
         see = [] :: [cuttlefish_variable:variable()],
@@ -61,6 +62,7 @@
     doc/1,
     see/1,
     include_default/1,
+    config_file_default/1,
     replace/2,
     validators/1,
     validators/2,
@@ -101,6 +103,7 @@ parse({mapping, Variable, Mapping, Proplist}) ->
                 doc = proplists:get_value(doc, Proplist, []),
                 see = proplists:get_value(see, Proplist, []),
                 include_default = proplists:get_value(include_default, Proplist),
+                config_file_default = proplists:get_value(config_file_default, Proplist),
                 validators = proplists:get_value(validators, Proplist, []),
                 hidden = proplists:get_value(hidden, Proplist, false)
             }
@@ -144,6 +147,7 @@ merge(NewMappingSource, OldMapping) ->
         level = choose(level, NewMappingSource, MergeMapping, OldMapping),
         doc = choose(doc, NewMappingSource, MergeMapping, OldMapping),
         include_default = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
+        config_file_default = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
         validators = choose(validators, NewMappingSource, MergeMapping, OldMapping),
         see = choose(see, NewMappingSource, MergeMapping, OldMapping),
         hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping)
@@ -206,6 +210,9 @@ see(M) -> M#mapping.see.
 
 -spec include_default(mapping()) -> string() | undefined.
 include_default(M) -> M#mapping.include_default.
+
+-spec config_file_default(mapping()) -> string() | undefined.
+config_file_default(M) -> M#mapping.config_file_default.
 
 -spec validators(mapping()) -> [string()].
 validators(M) -> M#mapping.validators.

--- a/src/cuttlefish_mapping.erl
+++ b/src/cuttlefish_mapping.erl
@@ -35,7 +35,7 @@
         level = basic :: basic | intermediate | advanced,
         doc = [] :: list(),
         include_default = undefined :: string() | undefined,
-        config_file_default = undefined :: string() | undefined,
+        new_conf_value = undefined :: string() | undefined,
         validators = [] :: [string()],
         is_merge = false :: boolean(),
         see = [] :: [cuttlefish_variable:variable()],
@@ -62,7 +62,7 @@
     doc/1,
     see/1,
     include_default/1,
-    config_file_default/1,
+    new_conf_value/1,
     replace/2,
     validators/1,
     validators/2,
@@ -103,7 +103,7 @@ parse({mapping, Variable, Mapping, Proplist}) ->
                 doc = proplists:get_value(doc, Proplist, []),
                 see = proplists:get_value(see, Proplist, []),
                 include_default = proplists:get_value(include_default, Proplist),
-                config_file_default = proplists:get_value(config_file_default, Proplist),
+                new_conf_value = proplists:get_value(new_conf_value, Proplist),
                 validators = proplists:get_value(validators, Proplist, []),
                 hidden = proplists:get_value(hidden, Proplist, false)
             }
@@ -147,7 +147,7 @@ merge(NewMappingSource, OldMapping) ->
         level = choose(level, NewMappingSource, MergeMapping, OldMapping),
         doc = choose(doc, NewMappingSource, MergeMapping, OldMapping),
         include_default = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
-        config_file_default = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
+        new_conf_value = choose(include_default, NewMappingSource, MergeMapping, OldMapping),
         validators = choose(validators, NewMappingSource, MergeMapping, OldMapping),
         see = choose(see, NewMappingSource, MergeMapping, OldMapping),
         hidden = choose(hidden, NewMappingSource, MergeMapping, OldMapping)
@@ -211,8 +211,8 @@ see(M) -> M#mapping.see.
 -spec include_default(mapping()) -> string() | undefined.
 include_default(M) -> M#mapping.include_default.
 
--spec config_file_default(mapping()) -> string() | undefined.
-config_file_default(M) -> M#mapping.config_file_default.
+-spec new_conf_value(mapping()) -> string() | undefined.
+new_conf_value(M) -> M#mapping.new_conf_value.
 
 -spec validators(mapping()) -> [string()].
 validators(M) -> M#mapping.validators.
@@ -261,7 +261,7 @@ mapping_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_config_file_val"},
+            {new_conf_value, "config_file_val"},
             {doc, ["documentation", "for feature"]},
             {validators, ["valid.the.impailer"]},
             hidden
@@ -277,7 +277,7 @@ mapping_test() ->
     ?assertEqual([{enum, [on, off]}], Record#mapping.datatype),
     ?assertEqual(["documentation", "for feature"], Record#mapping.doc),
     ?assertEqual("default_substitution", Record#mapping.include_default),
-    ?assertEqual("default_config_file_val", Record#mapping.config_file_default),
+    ?assertEqual("config_file_val", Record#mapping.new_conf_value),
     ?assertEqual(["valid.the.impailer"], Record#mapping.validators),
     ?assertEqual(true, Record#mapping.hidden),
 
@@ -289,7 +289,7 @@ mapping_test() ->
     ?assertEqual([{enum, [on, off]}], datatype(Record)),
     ?assertEqual(["documentation", "for feature"], doc(Record)),
     ?assertEqual("default_substitution", include_default(Record)),
-    ?assertEqual("default_config_file_val", config_file_default(Record)),
+    ?assertEqual("config_file_val", new_conf_value(Record)),
     ?assertEqual(["valid.the.impailer"], validators(Record)),
     ?assertEqual(true, hidden(Record)),
 
@@ -306,7 +306,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_conf_val18"},
+            {new_conf_value, "conf_val18"},
             {doc, ["documentation", "for feature"]}
         ]
     }),
@@ -322,7 +322,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_conf_val_A"},
+            {new_conf_value, "conf_val_A"},
             {doc, ["documentation", "for feature"]}
         ]
     })
@@ -338,7 +338,7 @@ replace_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_conf_val_B"},
+            {new_conf_value, "conf_val_B"},
             {doc, ["documentation", "for feature"]}
         ]
     }),
@@ -401,7 +401,7 @@ parse_and_merge_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_conf_val_A"},
+            {new_conf_value, "conf_val_A"},
             {doc, ["documentation", "for feature"]},
             hidden
         ]
@@ -416,7 +416,7 @@ parse_and_merge_test() ->
             {datatype, {enum, [on, off]}},
             {commented, "commented value"},
             {include_default, "default_substitution"},
-            {config_file_default, "default_conf_val_B"},
+            {new_conf_value, "conf_val_B"},
             {doc, ["documentation", "for feature"]}
         ]
     })


### PR DESCRIPTION
We don't currently have a way to specify that a default value should be written into generated config files without making it the default for all scenarios. For example, we want to be able to generate a config file that enables a new feature by default on fresh installations, but without automatically enabling that feature for anyone upgrading from an older version of the software.

Right now the only way to cause a field to show up in generated config is by setting the `default` attribute, but then that value is used as a default even if/when the corresponding flag is not present in the config file at all.

To address this scenario, this PR adds a `config_file_default` attribute. Setting this attribute will cause its value to be used as a default when generating a config file, but will otherwise have no effect.

TODO: We will probably want to add documentation for this feature, but lack of this functionality is currently blocking @matthewvon 's LZ4 work, so I'm going to PR the code now and update the docs later as a separate task.
