### PR TITLE
Fix OTP comparison

### DIFF
--- a/src/cuttlefish.erl
+++ b/src/cuttlefish.erl
@@ -52,6 +52,15 @@ otp(DesiredMinimumOTPVersion, IfGreaterOrEqual, IfLessThan) ->
 otp([], []) ->
     %% They're the same length AND all previous chars were matches
     true;
+otp([$R|TMin], [$R|TVer]) ->
+	%% Both start with R, strip this char
+	otp(TMin, TVer);
+otp([$R|TMin], Ver) ->
+	%% Minimum starts with R, strip this char
+	otp(TMin, Ver);
+otp(Min, [$R|TVer]) ->
+	%% Version starts with R, strip this char
+	otp(Min, TVer);
 otp([H|TMin], [H|TVer]) ->
     %% The head chars are equal, test the tails
     otp(TMin, TVer);
@@ -135,6 +144,11 @@ otp_test() ->
     ?assert(otp("R16", "R16A")),
     ?assert(not(otp("R16B01", "R16A"))),
     ?assert(otp("R16A", "R16A")),
+	?assert(otp("17", "17")),
+	?assert(otp("R16", "17")),
+	?assert(not(otp("17", "R16"))),
+	?assert(otp("R16", "20")),
+	?assert(not(otp("20", "R16"))),
     ok.
 
 -endif.

--- a/test/erlang_vm_schema_tests.erl
+++ b/test/erlang_vm_schema_tests.erl
@@ -29,12 +29,12 @@ basic_schema_test() ->
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_min"),
     cuttlefish_unit:assert_not_configured(Config, "kernel.inet_dist_listen_max"),
     case erlang:system_info(otp_release) of
-        [$R, $1, N|_] when N >= $6 ->
-            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 262144),
-            cuttlefish_unit:assert_config(Config, "vm_args.+e", 256000);
-        _ ->
+        [$R, $1, N|_] when N =< 5 ->
             cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_PORTS", 65536),
-            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 256000)
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 256000);
+        _ ->
+            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 262144),
+            cuttlefish_unit:assert_config(Config, "vm_args.+e", 256000)
     end,
     ok.
 
@@ -89,12 +89,12 @@ override_schema_test() ->
     %% because we don't know what version you're running, so we'll cover it
     %% in two tests below
     case erlang:system_info(otp_release) of
-        [$R, $1, N|_] when N >= $6 ->
-            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 32000),
-            cuttlefish_unit:assert_config(Config, "vm_args.+e", 128000);
-        _ ->
+        [$R, $1, N|_] when N =< $5 ->
             cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_PORTS", 32000),
-            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 128000)
+            cuttlefish_unit:assert_config(Config, "vm_args.-env ERL_MAX_ETS_TABLES", 128000);
+        _ ->
+            cuttlefish_unit:assert_config(Config, "vm_args.+Q", 32000),
+            cuttlefish_unit:assert_config(Config, "vm_args.+e", 128000)
     end,
     ok.
 


### PR DESCRIPTION
OTP 17 dropped the leading 'R' from the version number. Fix cuttlefish:otp/2
to order 'R16' before '17'. This function appeared to work correctly on R16,
but failed on OTP 17 and above.

New test cases added, and changed unit tests that set 'vm_args.-env ERL_MAX_*'
to only do this on R15 and below.
