### PR TITLE
Revert "Update lager to 3.2.1"

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {getopt, ".*", {git, "git://github.com/jcomellas/getopt.git", {tag, "v0.4.3"}}},
-    {lager, ".*", {git, "git://github.com/basho/lager.git", {tag, "3.2.1"}}},
+    {lager, "2.0.3", {git, "git://github.com/basho/lager.git", {tag, "2.0.3"}}},
     {neotoma, "1.7.2", {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.2"}}}
   ]}.
 


### PR DESCRIPTION
Reverts basho/cuttlefish#224 (RIAK-2227)

2.0 branch nees to stay on old Lager (semver and all).
