### PR TITLE
Permit zero in cuttlefish duration datatype

### DIFF
--- a/src/cuttlefish_duration_parse.peg
+++ b/src/cuttlefish_duration_parse.peg
@@ -8,7 +8,7 @@ duration_segment <- (float / integer) unit `
     Amount * Multiplier
 `;
 
-integer <- [1-9] [0-9]* `list_to_integer(?FLATTEN(Node))`;
+integer <- [0-9]+ `list_to_integer(?FLATTEN(Node))`;
 
 unit <- "f" / "w" / "d" / "h" / "ms" / "m" / "s"  `binary_to_atom(Node, latin1)`;
 


### PR DESCRIPTION
When parsing a duration, the current regular expression for "integer" prohibits values that have a leading '0'.  This also include the value "0ms", such as in the AAE throttle setting `anti_entropy.throttle.tier1.delay = 0ms`. 

The `list_to_integer` call in the integer definition deals with the leading zeros properly.  However, if it is desired to prohibit leading zeros for aesthetic reasons while permitting the value '0ms', the regular expression `( ([1-9] [0-9]* ) / "0" )` can be used.