### PR TITLE
Added basic type handling for proplist keys 

### DIFF
--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -25,10 +25,10 @@
 
 -export([build/3]).
 
-%%-ifdef(TEST).
+-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
-%%-endif.
+-endif.
 
 -spec build(cuttlefish_conf:conf(), cuttlefish_schema:schema(), [proplists:property()]) -> [string()].
 build(Conf, {_Translations, Mappings, _Validators} = _Schema, AdvConfig) ->

--- a/src/cuttlefish_effective.erl
+++ b/src/cuttlefish_effective.erl
@@ -25,10 +25,10 @@
 
 -export([build/3]).
 
--ifdef(TEST).
+%%-ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 -compile(export_all).
--endif.
+%%-endif.
 
 -spec build(cuttlefish_conf:conf(), cuttlefish_schema:schema(), [proplists:property()]) -> [string()].
 build(Conf, {_Translations, Mappings, _Validators} = _Schema, AdvConfig) ->
@@ -121,7 +121,7 @@ proplist_to_kvcpaths(Prefix, Proplist) ->
         _ -> Prefix ++ "."
     end,
     lists:foldl(fun(K, Acc) ->
-            KeyedPrefix = NewPrefix ++ atom_to_list(K),
+            KeyedPrefix = NewPrefix ++ canonicalize_key(K),
             R = proplist_to_kvcpaths(
                 KeyedPrefix,
                 proplists:get_value(K, Proplist)),
@@ -135,6 +135,19 @@ proplist_to_kvcpaths(Prefix, Proplist) ->
         [],
         keys_if_you_got_em(Proplist)
     ).
+
+%% So this is gross, but is the simplest scheme for determining the
+%% type of data coming into this function. It doesn't really
+%% matter how we handle non-atoms because cuttlefish only creates 
+%% proplists with atoms as the keynames.
+-spec canonicalize_key(atom() | list() | binary()) -> string().
+canonicalize_key(K) when is_atom(K) ->
+    atom_to_list(K);
+canonicalize_key(K) when is_list(K) ->
+    "\"" ++ K ++ "\"";
+canonicalize_key(K) when is_binary(K) ->
+    "<<\""++binary_to_list(K)++"\">>".
+
 
 -spec keys_if_you_got_em([proplists:property()]) -> [term()].
 keys_if_you_got_em(Proplist) when is_list(Proplist) ->


### PR DESCRIPTION
This was causing riak config effective to crash when it encountered non-atom proplist keys -- commonly used for Riak CS configuration