### PR TITLE
To be able to build it w/Erlang/OTP 19.x

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
-{require_otp_vsn, "R16|17|18|19"}.
+{require_otp_vsn, "R16|17|18|19|20"}.
 
-{erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
+{erl_opts, [{parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 
 {eunit_opts, [verbose]}.
 {cover_enabled, true}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{require_otp_vsn, "R16|17|18"}.
+{require_otp_vsn, "R16|17|18|19"}.
 
 {erl_opts, [warnings_as_errors, {parse_transform, lager_transform}, debug_info, warn_untyped_record]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {getopt, ".*", {git, "https://github.com/basho/getopt.git", {tag, "v0.8.2"}}},
-    {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.5.0"}}},
+    {lager, ".*", {git, "https://github.com/leo-project/lager.git", {branch, "for-leofs"}}},
     {neotoma, ".*", {git, "https://github.com/basho/neotoma.git", {tag, "1.7.4"}}}
   ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
 
 {deps, [
     {getopt, ".*", {git, "https://github.com/basho/getopt.git", {tag, "v0.8.2"}}},
-    {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "3.2.4"}}},
+    {lager, ".*", {git, "https://github.com/erlang-lager/lager.git", {tag, "3.5.0"}}},
     {neotoma, ".*", {git, "https://github.com/basho/neotoma.git", {tag, "1.7.4"}}}
   ]}.
 


### PR DESCRIPTION
I can not build cuttlefish with **Erlang/OTP 19.x**, so I modified `require_otp_vsn` of rebar.config.